### PR TITLE
Remove enable-heartbeat from daily CI

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -69,8 +69,6 @@ jobs:
           no-fuzz-afl,
           no-fuzz-libfuzzer,
           no-gost,
-          enable-heartbeats,
-          no-heartbeats,
           no-hw,
           no-hw-padlock,
           no-idea,


### PR DESCRIPTION
The enable-heartbeats test fails.  Remove it.

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
