### PR TITLE
Port windows PEM performance patch

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -235,15 +235,6 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
                 _setmode(fd, _O_TEXT);
             else
                 _setmode(fd, _O_BINARY);
-            /*
-             * Reports show that ftell() isn't trustable in text mode.
-             * This has been confirmed as a bug in the Universal C RTL, see
-             * https://developercommunity.visualstudio.com/content/problem/425878/fseek-ftell-fail-in-text-mode-for-unix-style-text.html
-             * The suggested work-around from Microsoft engineering is to
-             * turn off buffering until the bug is resolved.
-             */
-            if ((num & BIO_FP_TEXT) != 0)
-                setvbuf((FILE *)ptr, NULL, _IONBF, 0);
 # elif defined(OPENSSL_SYS_MSDOS)
             int fd = fileno((FILE *)ptr);
             /* Set correct text/binary mode */

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -422,7 +422,11 @@ static EVP_PKEY *openssl_load_privkey(ENGINE *eng, const char *key_id,
     EVP_PKEY *key;
     fprintf(stderr, "(TEST_ENG_OPENSSL_PKEY)Loading Private key %s\n",
             key_id);
+# if defined(OPENSSL_SYS_WINDOWS)
+    in = BIO_new_file(key_id, "rb");
+# else
     in = BIO_new_file(key_id, "r");
+# endif
     if (!in)
         return NULL;
     key = PEM_read_bio_PrivateKey(in, NULL, 0, NULL);

--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -50,7 +50,11 @@ X509 *TS_CONF_load_cert(const char *file)
     BIO *cert = NULL;
     X509 *x = NULL;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((cert = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((cert = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     x = PEM_read_bio_X509_AUX(cert, NULL, NULL, NULL);
  end:
@@ -67,7 +71,11 @@ STACK_OF(X509) *TS_CONF_load_certs(const char *file)
     STACK_OF(X509_INFO) *allcerts = NULL;
     int i;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((certs = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((certs = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     if ((othercerts = sk_X509_new_null()) == NULL)
         goto end;
@@ -98,7 +106,11 @@ EVP_PKEY *TS_CONF_load_key(const char *file, const char *pass)
     BIO *key = NULL;
     EVP_PKEY *pkey = NULL;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((key = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((key = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, (char *)pass);
  end:

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -228,7 +228,11 @@ int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
 
     if (type != X509_FILETYPE_PEM)
         return X509_load_cert_file_ex(ctx, file, type, libctx, propq);
+#if defined(OPENSSL_SYS_WINDOWS)
+    in = BIO_new_file(file, "rb");
+#else
     in = BIO_new_file(file, "r");
+#endif
     if (in == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_BIO_LIB);
         return 0;


### PR DESCRIPTION
This port https://github.com/openssl/openssl/pull/25716 to QuicTLS.

A more clean solution would be to have a single function BIO_pem_open or something but c'est la vie.

- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)

