### PR TITLE
Standardize #if defined constructs

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -327,10 +327,10 @@ static int ends_with_dirsep(const char *path)
 {
     if (*path != '\0')
         path += strlen(path) - 1;
-# if defined __VMS
+# if defined(__VMS)
     if (*path == ']' || *path == '>' || *path == ':')
         return 1;
-# elif defined _WIN32
+# elif defined(_WIN32)
     if (*path == '\\')
         return 1;
 # endif

--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -210,7 +210,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
     .popsection;
 #  endif
 
-# endif  /* defined __ASSEMBLER__ */
+# endif  /* defined(__ASSEMBLER__) */
 
 # define IS_CPU_SUPPORT_UNROLL8_EOR3() \
            (OPENSSL_armcap_P & ARMV8_UNROLL8_EOR3)

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -115,7 +115,7 @@ static unsigned long getauxval(unsigned long key)
 # ifndef AT_HWCAP2
 #  define AT_HWCAP2              26
 # endif
-# if defined(__arm__) || defined (__arm)
+# if defined(__arm__) || defined(__arm)
 #  define OSSL_HWCAP                  AT_HWCAP
 #  define OSSL_HWCAP_NEON             (1 << 12)
 

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -29,13 +29,13 @@ static int wsa_init_done = 0;
 #  if defined(OPENSSL_TANDEM_FLOSS)
 #   include <floss.h(floss_select)>
 #  endif
-# elif defined _WIN32
+# elif defined(_WIN32)
 #  include <winsock.h> /* for type fd_set */
 # else
 #  include <unistd.h>
-#  if defined __VMS
+#  if defined(__VMS)
 #   include <sys/socket.h>
-#  elif defined _HPUX_SOURCE
+#  elif defined(_HPUX_SOURCE)
 #   include <sys/time.h>
 #  else
 #   include <sys/select.h>

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -906,7 +906,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                                   &sockopt_val, sizeof(sockopt_val))) < 0)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling setsockopt()");
-# elif defined(OPENSSL_SYS_LINUX) && defined(IP_MTU_DISCOVER) && defined (IP_PMTUDISC_PROBE)
+# elif defined(OPENSSL_SYS_LINUX) && defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_PROBE)
             sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT;
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0)

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -32,7 +32,7 @@
 # include <lib$routines.h>
 # include <starlet.h>
 /* Some compiler options may mask the declaration of "_malloc32". */
-# if __INITIAL_POINTER_SIZE && defined _ANSI_C_SOURCE
+# if __INITIAL_POINTER_SIZE && defined(_ANSI_C_SOURCE)
 #  if __INITIAL_POINTER_SIZE == 64
 #   pragma pointer_size save
 #   pragma pointer_size 32

--- a/crypto/bn/asm/mips.pl
+++ b/crypto/bn/asm/mips.pl
@@ -89,7 +89,7 @@ if ($flavour =~ /64|n32/i) {
 	$SZREG=4;
 	$REG_S="sw";
 	$REG_L="lw";
-	$code="#if !(defined (__mips_isa_rev) && (__mips_isa_rev >= 6))\n.set     mips2\n#endif\n";
+	$code="#if !(defined(__mips_isa_rev) && (__mips_isa_rev >= 6))\n.set     mips2\n#endif\n";
 }
 
 $output and open STDOUT,">$output";

--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -161,7 +161,7 @@ static int bn_left_align(BIGNUM *num)
 # if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM) \
     && !defined(PEDANTIC) && !defined(BN_DIV3W)
 #  if defined(__GNUC__) && __GNUC__>=2
-#   if defined(__i386) || defined (__i386__)
+#   if defined(__i386) || defined(__i386__)
    /*-
     * There were two reasons for implementing this template:
     * - GNU C generates a call to a function (__udivdi3 to be exact)

--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -23,7 +23,7 @@
 
 /* Some compiler options may mask the declaration of "_malloc32". */
 # define DSO_MALLOC OPENSSL_malloc
-# if __INITIAL_POINTER_SIZE && defined _ANSI_C_SOURCE
+# if __INITIAL_POINTER_SIZE && defined(_ANSI_C_SOURCE)
 #  if __INITIAL_POINTER_SIZE == 64
 #   pragma pointer_size save
 #   pragma pointer_size 32
@@ -101,7 +101,7 @@ static int vms_load(DSO *dso)
     char *filename = DSO_convert_filename(dso, NULL);
 
 /* Ensure 32-bit pointer for "p", and appropriate malloc() function. */
-# if __INITIAL_POINTER_SIZE && defined _ANSI_C_SOURCE
+# if __INITIAL_POINTER_SIZE && defined(_ANSI_C_SOURCE)
 #  if __INITIAL_POINTER_SIZE == 64
 #   pragma pointer_size save
 #   pragma pointer_size 32
@@ -111,7 +111,7 @@ static int vms_load(DSO *dso)
 
     DSO_VMS_INTERNAL *p = NULL;
 
-# if __INITIAL_POINTER_SIZE && defined _ANSI_C_SOURCE
+# if __INITIAL_POINTER_SIZE && defined(_ANSI_C_SOURCE)
 #  if __INITIAL_POINTER_SIZE == 64
 #   pragma pointer_size restore
 #  endif                        /* __INITIAL_POINTER_SIZE == 64 */

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -498,7 +498,7 @@ static int sh_init(size_t size, size_t minsize)
         goto err;
 
     /* Allocate space for heap, and two extra pages as guards */
-#if defined(_SC_PAGE_SIZE) || defined (_SC_PAGESIZE)
+#if defined(_SC_PAGE_SIZE) || defined(_SC_PAGESIZE)
     {
 # if defined(_SC_PAGE_SIZE)
         long tmppgsize = sysconf(_SC_PAGE_SIZE);

--- a/crypto/o_dir.c
+++ b/crypto/o_dir.c
@@ -23,14 +23,14 @@
 #include "internal/o_dir.h"
 
 #define LPDIR_H
-#if defined OPENSSL_SYS_UNIX || defined DJGPP \
-    || (defined __VMS_VER && __VMS_VER >= 70000000)
+#if defined OPENSSL_SYS_UNIX || defined(DJGPP) \
+    || (defined(__VMS_VER) && __VMS_VER >= 70000000)
 # include "LPdir_unix.c"
-#elif defined OPENSSL_SYS_VMS
+#elif defined(OPENSSL_SYS_VMS)
 # include "LPdir_vms.c"
-#elif defined OPENSSL_SYS_WIN32
+#elif defined(OPENSSL_SYS_WIN32)
 # include "LPdir_win32.c"
-#elif defined OPENSSL_SYS_WINCE
+#elif defined(OPENSSL_SYS_WINCE)
 # include "LPdir_wince.c"
 #else
 # include "LPdir_nyi.c"

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -29,7 +29,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
 # pragma pointer_size 32
 #endif
         struct tm data, *ts2 = &data;
-#if defined OPENSSL_SYS_VMS && __INITIAL_POINTER_SIZE
+#if defined(OPENSSL_SYS_VMS) && __INITIAL_POINTER_SIZE
 # pragma pointer_size restore
 #endif
         if (gmtime_r(timer, ts2) == NULL)
@@ -41,7 +41,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;
-#elif defined (OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400 && !defined(_WIN32_WCE)
+#elif defined(OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400 && !defined(_WIN32_WCE)
     if (gmtime_s(result, timer))
         return NULL;
     ts = result;

--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -9,7 +9,7 @@
 
 #include "internal/cryptlib.h"
 #include "internal/packet.h"
-#if !defined OPENSSL_NO_QUIC && !defined FIPS_MODULE
+#if !defined(OPENSSL_NO_QUIC) && !defined(FIPS_MODULE)
 # include "internal/packet_quic.h"
 #endif
 #include <openssl/err.h>
@@ -226,7 +226,7 @@ static int put_value(unsigned char *data, uint64_t value, size_t len)
     return 1;
 }
 
-#if !defined OPENSSL_NO_QUIC && !defined FIPS_MODULE
+#if !defined(OPENSSL_NO_QUIC) && !defined(FIPS_MODULE)
 static int put_quic_value(unsigned char *data, size_t value, size_t len)
 {
     if (data == NULL)
@@ -277,7 +277,7 @@ static int wpacket_intern_close(WPACKET *pkt, WPACKET_SUB *sub, int doclose)
         unsigned char *buf = GETBUF(pkt);
 
         if (buf != NULL) {
-#if !defined OPENSSL_NO_QUIC && !defined FIPS_MODULE
+#if !defined(OPENSSL_NO_QUIC) && !defined(FIPS_MODULE)
             if ((sub->flags & WPACKET_FLAGS_QUIC_VLINT) == 0) {
                 if (!put_value(&buf[sub->packet_len], packlen, sub->lenbytes))
                     return 0;
@@ -534,7 +534,7 @@ void WPACKET_cleanup(WPACKET *pkt)
     pkt->subs = NULL;
 }
 
-#if !defined OPENSSL_NO_QUIC && !defined FIPS_MODULE
+#if !defined(OPENSSL_NO_QUIC) && !defined(FIPS_MODULE)
 
 int WPACKET_start_quic_sub_packet_bound(WPACKET *pkt, size_t max_len)
 {

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#if defined (__TANDEM) && defined (_SPT_MODEL_)
+#if defined(__TANDEM) && defined(_SPT_MODEL_)
 /*
  * These definitions have to come first in SPT due to scoping of the
  * declarations in c99 associated with SPT use of stat.

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -635,7 +635,7 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
      * We don't use recursive mutexes, but try to catch errors if we do.
      */
     pthread_mutexattr_init(&attr);
-#  if !defined (__TANDEM) && !defined (_SPT_MODEL_)
+#  if !defined(__TANDEM) && !defined(_SPT_MODEL_)
 #   if !defined(NDEBUG) && !defined(OPENSSL_NO_MUTEX_ERRORCHECK)
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
 #   endif

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#if defined (__TANDEM) && defined (_SPT_MODEL_)
+#if defined(__TANDEM) && defined(_SPT_MODEL_)
   /*
    * These definitions have to come first in SPT due to scoping of the
    * declarations in c99 associated with SPT use of stat.

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -252,27 +252,27 @@ static int padlock_available(void)
 
 /* ===== AES encryption/decryption ===== */
 
-#  if defined(NID_aes_128_cfb128) && ! defined (NID_aes_128_cfb)
+#  if defined(NID_aes_128_cfb128) && ! defined(NID_aes_128_cfb)
 #   define NID_aes_128_cfb NID_aes_128_cfb128
 #  endif
 
-#  if defined(NID_aes_128_ofb128) && ! defined (NID_aes_128_ofb)
+#  if defined(NID_aes_128_ofb128) && ! defined(NID_aes_128_ofb)
 #   define NID_aes_128_ofb NID_aes_128_ofb128
 #  endif
 
-#  if defined(NID_aes_192_cfb128) && ! defined (NID_aes_192_cfb)
+#  if defined(NID_aes_192_cfb128) && ! defined(NID_aes_192_cfb)
 #   define NID_aes_192_cfb NID_aes_192_cfb128
 #  endif
 
-#  if defined(NID_aes_192_ofb128) && ! defined (NID_aes_192_ofb)
+#  if defined(NID_aes_192_ofb128) && ! defined(NID_aes_192_ofb)
 #   define NID_aes_192_ofb NID_aes_192_ofb128
 #  endif
 
-#  if defined(NID_aes_256_cfb128) && ! defined (NID_aes_256_cfb)
+#  if defined(NID_aes_256_cfb128) && ! defined(NID_aes_256_cfb)
 #   define NID_aes_256_cfb NID_aes_256_cfb128
 #  endif
 
-#  if defined(NID_aes_256_ofb128) && ! defined (NID_aes_256_ofb)
+#  if defined(NID_aes_256_ofb128) && ! defined(NID_aes_256_ofb)
 #   define NID_aes_256_ofb NID_aes_256_ofb128
 #  endif
 

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -116,8 +116,8 @@ OSSL_LIB_CTX *ossl_bn_get_libctx(BN_CTX *ctx);
 
 extern const BIGNUM ossl_bn_inv_sqrt_2;
 
-#if defined(OPENSSL_SYS_LINUX) && !defined(FIPS_MODULE) && defined (__s390x__) \
-    && !defined (OPENSSL_NO_ASM)
+#if defined(OPENSSL_SYS_LINUX) && !defined(FIPS_MODULE) && defined(__s390x__) \
+    && !defined(OPENSSL_NO_ASM)
 # define S390X_MOD_EXP
 #endif
 

--- a/include/crypto/sm4_platform.h
+++ b/include/crypto/sm4_platform.h
@@ -12,7 +12,7 @@
 # pragma once
 
 # if defined(OPENSSL_CPUID_OBJ)
-#  if defined(__aarch64__) ||  defined (_M_ARM64)
+#  if defined(__aarch64__) ||  defined(_M_ARM64)
 #   include "arm_arch.h"
 extern unsigned int OPENSSL_arm_midr;
 static inline int vpsm4_capable(void)

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -188,10 +188,10 @@ static ossl_inline int ossl_ends_with_dirsep(const char *path)
 {
     if (*path != '\0')
         path += strlen(path) - 1;
-# if defined __VMS
+# if defined(__VMS)
     if (*path == ']' || *path == '>' || *path == ':')
         return 1;
-# elif defined _WIN32
+# elif defined(_WIN32)
     if (*path == '\\')
         return 1;
 # endif
@@ -214,13 +214,13 @@ static ossl_inline char ossl_determine_dirsep(const char *path)
 
 static ossl_inline int ossl_is_absolute_path(const char *path)
 {
-# if defined __VMS
+# if defined(__VMS)
     if (strchr(path, ':') != NULL
         || ((path[0] == '[' || path[0] == '<')
             && path[1] != '.' && path[1] != '-'
             && path[1] != ']' && path[1] != '>'))
         return 1;
-# elif defined _WIN32
+# elif defined(_WIN32)
     if (path[0] == '\\'
         || (path[0] != '\0' && path[1] == ':'))
         return 1;

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -24,4 +24,4 @@
 
 # endif
 
-#endif                          /* ! defined HEADER_VMS_IDHACKS_H */
+#endif

--- a/include/openssl/symhacks.h
+++ b/include/openssl/symhacks.h
@@ -36,4 +36,4 @@
 
 # endif
 
-#endif                          /* ! defined HEADER_VMS_IDHACKS_H */
+#endif

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -198,7 +198,7 @@ void OSSL_trace_end(int category, BIO *channel);
  * call OSSL_TRACE_CANCEL(category).
  */
 
-# if !defined OPENSSL_NO_TRACE && !defined FIPS_MODULE
+# if !defined(OPENSSL_NO_TRACE) && !defined(FIPS_MODULE)
 
 #  define OSSL_TRACE_BEGIN(category) \
     do { \
@@ -237,7 +237,7 @@ void OSSL_trace_end(int category, BIO *channel);
  *         ...
  *     }
  */
-# if !defined OPENSSL_NO_TRACE && !defined FIPS_MODULE
+# if !defined(OPENSSL_NO_TRACE) && !defined(FIPS_MODULE)
 
 #  define OSSL_TRACE_ENABLED(category) \
     OSSL_trace_enabled(OSSL_TRACE_CATEGORY_##category)
@@ -270,7 +270,7 @@ void OSSL_trace_end(int category, BIO *channel);
  *                42, "What do you get when you multiply six by nine?");
  */
 
-# if !defined OPENSSL_NO_TRACE && !defined FIPS_MODULE
+# if !defined(OPENSSL_NO_TRACE) && !defined(FIPS_MODULE)
 
 #  define OSSL_TRACEV(category, args) \
     OSSL_TRACE_BEGIN(category) \

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -146,7 +146,7 @@ const PROV_CIPHER_HW *ossl_prov_cipher_hw_aes_##mode(size_t keybits)           \
 # include "cipher_aes_hw_rv64i.inc"
 #elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
 # include "cipher_aes_hw_rv32i.inc"
-#elif defined (ARMv8_HWAES_CAPABLE)
+#elif defined(ARMv8_HWAES_CAPABLE)
 # include "cipher_aes_hw_armv8.inc"
 #else
 /* The generic case */

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -496,7 +496,7 @@ static int wait_random_seeded(void)
     }
     return seeded;
 }
-#   else /* defined __linux && DEVRANDOM_WAIT && OPENSSL_RAND_SEED_GETRANDOM */
+#   else /* defined(__linux) && DEVRANDOM_WAIT && OPENSSL_RAND_SEED_GETRANDOM */
 static int wait_random_seeded(void)
 {
     return 1;

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1298,7 +1298,7 @@ static int test_evp_md_ctx_copy(void)
     return ret;
 }
 
-#if !defined OPENSSL_NO_DES && !defined OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_MD5)
 static int test_evp_pbe_alg_add(void)
 {
     int ret = 0;
@@ -1392,7 +1392,7 @@ int setup_tests(void)
     ADD_TEST(test_evp_md_ctx_dup);
     ADD_TEST(test_evp_md_ctx_copy);
     ADD_ALL_TESTS(test_provider_unload_effective, 2);
-#if !defined OPENSSL_NO_DES && !defined OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_MD5)
     ADD_TEST(test_evp_pbe_alg_add);
 #endif
     return 1;

--- a/test/pbetest.c
+++ b/test/pbetest.c
@@ -18,8 +18,8 @@
 #include <openssl/configuration.h>
 #include <openssl/provider.h>
 
-#if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5 \
-    || !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_MD5) \
+    || !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_SHA1)
 static const char pbe_password[] = "MyVoiceIsMyPassport";
 
 static unsigned char pbe_salt[] = {
@@ -37,7 +37,7 @@ static unsigned char pbe_plaintext[] = {
 
 /* Expected output generated using OpenSSL 1.1.1 */
 
-#if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_MD5)
 static const unsigned char pbe_ciphertext_rc4_md5[] = {
     0x21, 0x90, 0xfa, 0xee, 0x95, 0x66, 0x59, 0x45,
     0xfa, 0x1e, 0x9f, 0xe2, 0x25, 0xd2, 0xf9, 0x71,
@@ -45,7 +45,7 @@ static const unsigned char pbe_ciphertext_rc4_md5[] = {
 };
 #endif
 
-#if !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_SHA1)
 static const unsigned char pbe_ciphertext_des_sha1[] = {
     0xce, 0x4b, 0xb0, 0x0a, 0x7b, 0x48, 0xd7, 0xe3,
     0x9a, 0x9f, 0x46, 0xd6, 0x41, 0x42, 0x4b, 0x44,
@@ -54,8 +54,8 @@ static const unsigned char pbe_ciphertext_des_sha1[] = {
 };
 #endif
 
-#if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5 \
-    || !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_MD5) \
+    || !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_SHA1)
 static int test_pkcs5_pbe(const EVP_CIPHER *cipher, const EVP_MD *md,
                           const unsigned char *exp, const int exp_len)
 {
@@ -111,14 +111,14 @@ err:
 }
 #endif
 
-#if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_MD5)
 static int test_pkcs5_pbe_rc4_md5(void)
 {
     return test_pkcs5_pbe(EVP_rc4(), EVP_md5(), pbe_ciphertext_rc4_md5, sizeof(pbe_ciphertext_rc4_md5));
 }
 #endif
 
-#if !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_SHA1)
 static int test_pkcs5_pbe_des_sha1(void)
 {
     return test_pkcs5_pbe(EVP_des_cbc(), EVP_sha1(), pbe_ciphertext_des_sha1, sizeof(pbe_ciphertext_des_sha1));
@@ -146,10 +146,10 @@ int setup_tests(void)
     }
 #endif
 
-#if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_MD5)
     ADD_TEST(test_pkcs5_pbe_rc4_md5);
 #endif
-#if !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_SHA1)
     ADD_TEST(test_pkcs5_pbe_des_sha1);
 #endif
 


### PR DESCRIPTION
Always use "#if defined(xxx)" not "defined (xxx)" or "defined xxx"

This might help (I hope) in removing some old platforms.