### PR TITLE
Trim down on-push CI jobs

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -22,59 +22,12 @@ jobs:
             cc: gcc-7,
             distro: ubuntu-20.04
           }, {
-            cc: gcc-8,
-            distro: ubuntu-20.04
-          }, {
-            cc: gcc-9,
-            distro: ubuntu-20.04
-          }, {
-            cc: gcc-10,
-            distro: ubuntu-20.04
-          }, {
-            cc: gcc-11,
-            distro: ubuntu-22.04
-          }, {
-            cc: gcc-12,
-            distro: ubuntu-22.04
-          }, {
             cc: gcc-13,
             distro: ubuntu-22.04,
             gcc-ppa-name: ubuntu-toolchain-r/test
           }, {
             cc: clang-6.0,
             distro: ubuntu-20.04
-          }, {
-            cc: clang-7,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-8,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-9,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-10,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-11,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-12,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-13,
-            distro: ubuntu-22.04
-          }, {
-            cc: clang-14,
-            distro: ubuntu-22.04
-          }, {
-            cc: clang-15,
-            distro: ubuntu-22.04,
-            llvm-ppa-name: jammy
-          }, {
-            cc: clang-16,
-            distro: ubuntu-22.04,
-            llvm-ppa-name: jammy
           }, {
             cc: clang-17,
             distro: ubuntu-22.04,

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -46,29 +46,14 @@ jobs:
             libs: libc6-dev-arm64-cross,
             target: linux-aarch64
           }, {
-            arch: alpha-linux-gnu,
-            libs: libc6.1-dev-alpha-cross,
-            target: linux-alpha-gcc
-          }, {
             arch: arm-linux-gnueabi,
             libs: libc6-dev-armel-cross,
-            target: linux-armv4,
-            tests: -test_includes -test_store -test_x509_store
-          }, {
-            arch: arm-linux-gnueabihf,
-            libs: libc6-dev-armhf-cross,
             target: linux-armv4,
             tests: -test_includes -test_store -test_x509_store
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
             target: -static -m68040 linux-latomic -Wno-stringop-overflow,
-            fips: no,
-            tests: -test_includes -test_store -test_x509_store
-          }, {
-            arch: mips-linux-gnu,
-            libs: libc6-dev-mips-cross,
-            target: -static linux-mips32,
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {
@@ -101,34 +86,6 @@ jobs:
             libs: libc6-dev-sh4-cross,
             target: no-async linux-latomic,
             tests: -test_includes -test_store -test_x509_store
-          },
-
-          # These build with shared libraries but they crash when run
-          # They mirror static builds above in order to cover more of the
-          # code base.
-          {
-            arch: m68k-linux-gnu,
-            libs: libc6-dev-m68k-cross,
-            target: -mcfv4e -mxgot linux-latomic -Wno-stringop-overflow no-quic,
-            tests: none
-          }, {
-            arch: mips-linux-gnu,
-            libs: libc6-dev-mips-cross,
-            target: linux-mips32,
-            tests: none
-          }, {
-            arch: mips64-linux-gnuabi64,
-            libs: libc6-dev-mips64-cross,
-            target: linux64-mips64,
-            tests: none
-          },
-
-          # This build doesn't execute either with or without shared libraries.
-          {
-            arch: sparc64-linux-gnu,
-            libs: libc6-dev-sparc64-cross,
-            target: linux64-sparcv9,
-            tests: none
           }
         ]
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}


### PR DESCRIPTION
For compiler-zoo: only test first and last gcc and clang. For cross-compile: remove sparc64-linux-gnu, mips64-linux-gnuabi64, mips-linux-gnu, m68k-linux-gnu, mips-linux-gnu, arm-linux-gnueabihf, andalpha-linux-gnu.

Fixes: #92

## Checklist
Thank you for your contribution. Please answer the following:

- [x] I acknowledge that I am authorized to submit this code under
