### PR TITLE
Use `inline` since it's in C99

### DIFF
--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -924,7 +924,7 @@ static void xor128(ARIA_c128 o, const ARIA_c128 x, const ARIA_u128 *y)
  * Generalised circular rotate right and exclusive or function.
  * It is safe for the output to overlap either input.
  */
-static ossl_inline void rotnr(unsigned int n, ARIA_u128 *o,
+static inline void rotnr(unsigned int n, ARIA_u128 *o,
                               const ARIA_u128 *xor, const ARIA_u128 *z)
 {
     const unsigned int bytes = n / 8, bits = n % 8;
@@ -1059,7 +1059,7 @@ static void a(ARIA_u128 *y, const ARIA_u128 *x)
  * Apply the first substitution layer and then a diffusion step.
  * It is safe for the input and output to overlap.
  */
-static ossl_inline void FO(ARIA_u128 *o, const ARIA_u128 *d,
+static inline void FO(ARIA_u128 *o, const ARIA_u128 *d,
                            const ARIA_u128 *rk)
 {
     ARIA_u128 y;
@@ -1073,7 +1073,7 @@ static ossl_inline void FO(ARIA_u128 *o, const ARIA_u128 *d,
  * Apply the second substitution layer and then a diffusion step.
  * It is safe for the input and output to overlap.
  */
-static ossl_inline void FE(ARIA_u128 *o, const ARIA_u128 *d,
+static inline void FE(ARIA_u128 *o, const ARIA_u128 *d,
                            const ARIA_u128 *rk)
 {
     ARIA_u128 y;

--- a/crypto/asn1/evp_asn1.c
+++ b/crypto/asn1/evp_asn1.c
@@ -51,7 +51,7 @@ int ASN1_TYPE_get_octetstring(const ASN1_TYPE *a, unsigned char *data, int max_l
     return ret;
 }
 
-static ossl_inline void asn1_type_init_oct(ASN1_OCTET_STRING *oct,
+static inline void asn1_type_init_oct(ASN1_OCTET_STRING *oct,
                                            unsigned char *data, int len)
 {
     oct->data = data;

--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -64,7 +64,7 @@ typedef struct async_fibre_st {
 int async_local_init(void);
 void async_local_deinit(void);
 
-static ossl_inline int async_fibre_swapcontext(async_fibre *o, async_fibre *n, int r)
+static inline int async_fibre_swapcontext(async_fibre *o, async_fibre *n, int r)
 {
 #  ifdef USE_SWAPCONTEXT
     swapcontext(&o->fibre, &n->fibre);

--- a/crypto/bio/bss_core.c
+++ b/crypto/bio/bss_core.c
@@ -32,7 +32,7 @@ void *ossl_bio_core_globals_new(OSSL_LIB_CTX *ctx)
     return OPENSSL_zalloc(sizeof(BIO_CORE_GLOBALS));
 }
 
-static ossl_inline BIO_CORE_GLOBALS *get_globals(OSSL_LIB_CTX *libctx)
+static inline BIO_CORE_GLOBALS *get_globals(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_BIO_CORE_INDEX);
 }

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -1130,7 +1130,7 @@ static int dgram_mem_read(BIO *bio, char *buf, int sz_)
  * We use an expansion factor of 8 / 5 = 1.6
  */
 static const size_t max_rbuf_size = SIZE_MAX / 2; /* unlimited in practice */
-static ossl_inline size_t compute_rbuf_growth(size_t target, size_t current)
+static inline size_t compute_rbuf_growth(size_t target, size_t current)
 {
     int err = 0;
 

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -17,7 +17,7 @@
  * This is a static function, we ensure all callers in this file pass valid
  * arguments: all passed pointers here are non-NULL.
  */
-static ossl_inline
+static inline
 BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
                                  const BIGNUM *a, const BIGNUM *n,
                                  BN_CTX *ctx, int *pnoinv)

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -85,7 +85,7 @@ int BN_num_bits_word(BN_ULONG l)
  * This function still leaks `a->dmax`: it's caller's responsibility to
  * expand the input `a` in advance to a public length.
  */
-static ossl_inline
+static inline
 int bn_num_bits_consttime(const BIGNUM *a)
 {
     int j, ret;

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -666,7 +666,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
                            const BIGNUM *a, const BIGNUM *n, BN_CTX *ctx,
                            int *noinv);
 
-static ossl_inline BIGNUM *bn_expand(BIGNUM *a, int bits)
+static inline BIGNUM *bn_expand(BIGNUM *a, int bits)
 {
     if (bits > (INT_MAX - BN_BITS2 + 1))
         return NULL;

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -322,7 +322,7 @@ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
 #ifdef NIST_INT64
 /* Helpers to load/store a 32-bit word (uint32_t) from/into a memory
  * location and avoid potential aliasing issue.  */
-static ossl_inline uint32_t load_u32(const void *ptr)
+static inline uint32_t load_u32(const void *ptr)
 {
     uint32_t tmp;
 
@@ -330,7 +330,7 @@ static ossl_inline uint32_t load_u32(const void *ptr)
     return tmp;
 }
 
-static ossl_inline void store_lo32(void *ptr, NIST_INT64 val)
+static inline void store_lo32(void *ptr, NIST_INT64 val)
 {
     /* A cast is needed for big-endian system: on a 32-bit BE system
      * NIST_INT64 may be defined as well if the compiler supports 64-bit

--- a/crypto/bn/rsaz_exp.h
+++ b/crypto/bn/rsaz_exp.h
@@ -54,7 +54,7 @@ int ossl_rsaz_mod_exp_avx512_x2(BN_ULONG *res1,
                                 BN_ULONG k0_2,
                                 int factor_size);
 
-static ossl_inline void bn_select_words(BN_ULONG *r, BN_ULONG mask,
+static inline void bn_select_words(BN_ULONG *r, BN_ULONG mask,
                                         const BN_ULONG *a,
                                         const BN_ULONG *b, size_t num)
 {
@@ -65,7 +65,7 @@ static ossl_inline void bn_select_words(BN_ULONG *r, BN_ULONG mask,
     }
 }
 
-static ossl_inline BN_ULONG bn_reduce_once_in_place(BN_ULONG *r,
+static inline BN_ULONG bn_reduce_once_in_place(BN_ULONG *r,
                                                     BN_ULONG carry,
                                                     const BN_ULONG *m,
                                                     BN_ULONG *tmp, size_t num)

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -39,15 +39,15 @@ NON_EMPTY_TRANSLATION_UNIT
 # define NUMBER_OF_REGISTERS(digits_num, register_size)            \
     (((digits_num) * 64 + (register_size) - 1) / (register_size))
 
-static ossl_inline uint64_t get_digit(const uint8_t *in, int in_len);
-static ossl_inline void put_digit(uint8_t *out, int out_len, uint64_t digit);
+static inline uint64_t get_digit(const uint8_t *in, int in_len);
+static inline void put_digit(uint8_t *out, int out_len, uint64_t digit);
 static void to_words52(BN_ULONG *out, int out_len, const BN_ULONG *in,
                        int in_bitsize);
 static void from_words52(BN_ULONG *bn_out, int out_bitsize, const BN_ULONG *in);
-static ossl_inline void set_bit(BN_ULONG *a, int idx);
+static inline void set_bit(BN_ULONG *a, int idx);
 
 /* Number of |digit_size|-bit digits in |bitsize|-bit value */
-static ossl_inline int number_of_digits(int bitsize, int digit_size)
+static inline int number_of_digits(int bitsize, int digit_size)
 {
     return (bitsize + digit_size - 1) / digit_size;
 }
@@ -518,7 +518,7 @@ err:
     return ret;
 }
 
-static ossl_inline uint64_t get_digit(const uint8_t *in, int in_len)
+static inline uint64_t get_digit(const uint8_t *in, int in_len)
 {
     uint64_t digit = 0;
 
@@ -583,7 +583,7 @@ static void to_words52(BN_ULONG *out, int out_len,
     }
 }
 
-static ossl_inline void put_digit(uint8_t *out, int out_len, uint64_t digit)
+static inline void put_digit(uint8_t *out, int out_len, uint64_t digit)
 {
     assert(out != NULL);
     assert(out_len <= 8);
@@ -641,7 +641,7 @@ static void from_words52(BN_ULONG *out, int out_bitsize, const BN_ULONG *in)
  * It does not do any boundaries checks, make sure the index is valid before
  * calling the function.
  */
-static ossl_inline void set_bit(BN_ULONG *a, int idx)
+static inline void set_bit(BN_ULONG *a, int idx)
 {
     assert(a != NULL);
 

--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -129,7 +129,7 @@ int ossl_dh_is_foreign(const DH *dh)
     return 0;
 }
 
-static ossl_inline int dh_bn_dup_check(BIGNUM **out, const BIGNUM *f)
+static inline int dh_bn_dup_check(BIGNUM **out, const BIGNUM *f)
 {
     if (f != NULL && (*out = BN_dup(f)) == NULL)
         return 0;

--- a/crypto/dsa/dsa_backend.c
+++ b/crypto/dsa/dsa_backend.c
@@ -72,7 +72,7 @@ int ossl_dsa_is_foreign(const DSA *dsa)
     return 0;
 }
 
-static ossl_inline int dsa_bn_dup_check(BIGNUM **out, const BIGNUM *f)
+static inline int dsa_bn_dup_check(BIGNUM **out, const BIGNUM *f)
 {
     if (f != NULL && (*out = BN_dup(f)) == NULL)
         return 0;

--- a/crypto/ec/curve448/arch_32/arch_intrinsics.h
+++ b/crypto/ec/curve448/arch_32/arch_intrinsics.h
@@ -19,7 +19,7 @@
 
 #define word_is_zero(a)     constant_time_is_zero_32(a)
 
-static ossl_inline uint64_t widemul(uint32_t a, uint32_t b)
+static inline uint64_t widemul(uint32_t a, uint32_t b)
 {
     return ((uint64_t)a) * b;
 }

--- a/crypto/ec/curve448/arch_64/arch_intrinsics.h
+++ b/crypto/ec/curve448/arch_64/arch_intrinsics.h
@@ -19,7 +19,7 @@
 
 # define word_is_zero(a)     constant_time_is_zero_64(a)
 
-static ossl_inline uint128_t widemul(uint64_t a, uint64_t b)
+static inline uint128_t widemul(uint64_t a, uint64_t b)
 {
     return ((uint128_t) a) * b;
 }

--- a/crypto/ec/curve448/curve448.c
+++ b/crypto/ec/curve448/curve448.c
@@ -88,7 +88,7 @@ void ossl_curve448_point_double(curve448_point_t p, const curve448_point_t q)
 }
 
 /* Operations on [p]niels */
-static ossl_inline void cond_neg_niels(niels_t n, mask_t neg)
+static inline void cond_neg_niels(niels_t n, mask_t neg)
 {
     gf_cond_swap(n->a, n->b, neg);
     gf_cond_neg(n->c, neg);
@@ -220,7 +220,7 @@ ossl_curve448_point_valid(const curve448_point_t p)
     return mask_to_bool(out);
 }
 
-static ossl_inline void constant_time_lookup_niels(niels_s * RESTRICT ni,
+static inline void constant_time_lookup_niels(niels_s * RESTRICT ni,
                                                    const niels_t *table,
                                                    int nelts, int idx)
 {

--- a/crypto/ec/curve448/curve448utils.h
+++ b/crypto/ec/curve448/curve448utils.h
@@ -74,7 +74,7 @@ typedef enum {
 } c448_error_t;
 
 /* Return success if x is true */
-static ossl_inline c448_error_t c448_succeed_if(c448_bool_t x)
+static inline c448_error_t c448_succeed_if(c448_bool_t x)
 {
     return (c448_error_t) x;
 }

--- a/crypto/ec/curve448/field.h
+++ b/crypto/ec/curve448/field.h
@@ -27,7 +27,7 @@
 #  define RESTRICT __restrict__
 #  define ALIGNED __attribute__((__aligned__(16)))
 # else
-#  define INLINE_UNUSED ossl_inline
+#  define INLINE_UNUSED inline
 #  define RESTRICT
 #  define ALIGNED
 # endif
@@ -79,7 +79,7 @@ mask_t gf_deserialize(gf x, const uint8_t serial[SER_BYTES], int with_hibit,
 static const gf ZERO = {{{0}}}, ONE = {{{1}}};
 
 /* Square x, n times. */
-static ossl_inline void gf_sqrn(gf_s * RESTRICT y, const gf x, int n)
+static inline void gf_sqrn(gf_s * RESTRICT y, const gf x, int n)
 {
     gf tmp;
 
@@ -101,7 +101,7 @@ static ossl_inline void gf_sqrn(gf_s * RESTRICT y, const gf x, int n)
 # define gf_add_nr gf_add_RAW
 
 /* Subtract mod p.  Bias by 2 and don't reduce  */
-static ossl_inline void gf_sub_nr(gf c, const gf a, const gf b)
+static inline void gf_sub_nr(gf c, const gf a, const gf b)
 {
     gf_sub_RAW(c, a, b);
     gf_bias(c, 2);
@@ -110,7 +110,7 @@ static ossl_inline void gf_sub_nr(gf c, const gf a, const gf b)
 }
 
 /* Subtract mod p. Bias by amt but don't reduce.  */
-static ossl_inline void gf_subx_nr(gf c, const gf a, const gf b, int amt)
+static inline void gf_subx_nr(gf c, const gf a, const gf b, int amt)
 {
     gf_sub_RAW(c, a, b);
     gf_bias(c, amt);
@@ -119,7 +119,7 @@ static ossl_inline void gf_subx_nr(gf c, const gf a, const gf b, int amt)
 }
 
 /* Mul by signed int.  Not constant-time WRT the sign of that int. */
-static ossl_inline void gf_mulw(gf c, const gf a, int32_t w)
+static inline void gf_mulw(gf c, const gf a, int32_t w)
 {
     if (w > 0) {
         ossl_gf_mulw_unsigned(c, a, w);
@@ -130,7 +130,7 @@ static ossl_inline void gf_mulw(gf c, const gf a, int32_t w)
 }
 
 /* Constant time, x = is_z ? z : y */
-static ossl_inline void gf_cond_sel(gf x, const gf y, const gf z, mask_t is_z)
+static inline void gf_cond_sel(gf x, const gf y, const gf z, mask_t is_z)
 {
     size_t i;
 
@@ -147,7 +147,7 @@ static ossl_inline void gf_cond_sel(gf x, const gf y, const gf z, mask_t is_z)
 }
 
 /* Constant time, if (neg) x=-x; */
-static ossl_inline void gf_cond_neg(gf x, mask_t neg)
+static inline void gf_cond_neg(gf x, mask_t neg)
 {
     gf y;
 
@@ -156,7 +156,7 @@ static ossl_inline void gf_cond_neg(gf x, mask_t neg)
 }
 
 /* Constant time, if (swap) (x,y) = (y,x); */
-static ossl_inline void gf_cond_swap(gf x, gf_s * RESTRICT y, mask_t swap)
+static inline void gf_cond_swap(gf x, gf_s * RESTRICT y, mask_t swap)
 {
     size_t i;
 

--- a/crypto/ec/curve448/point_448.h
+++ b/crypto/ec/curve448/point_448.h
@@ -165,7 +165,7 @@ ossl_curve448_scalar_halve(curve448_scalar_t out, const curve448_scalar_t a);
  * a (in): A scalar.
  * out (out): Will become a copy of a.
  */
-static ossl_inline void curve448_scalar_copy(curve448_scalar_t out,
+static inline void curve448_scalar_copy(curve448_scalar_t out,
                                              const curve448_scalar_t a)
 {
     *out = *a;
@@ -178,7 +178,7 @@ static ossl_inline void curve448_scalar_copy(curve448_scalar_t out,
  * a (out): A copy of the point.
  * b (in): Any point.
  */
-static ossl_inline void curve448_point_copy(curve448_point_t a,
+static inline void curve448_point_copy(curve448_point_t a,
                                             const curve448_point_t b)
 {
     *a = *b;

--- a/crypto/ec/curve448/scalar.c
+++ b/crypto/ec/curve448/scalar.c
@@ -135,7 +135,7 @@ ossl_curve448_scalar_add(curve448_scalar_t out, const curve448_scalar_t a,
     sc_subx(out, out->limb, sc_p, sc_p, (c448_word_t)chain);
 }
 
-static ossl_inline void scalar_decode_short(curve448_scalar_t s,
+static inline void scalar_decode_short(curve448_scalar_t s,
                                             const unsigned char *ser,
                                             size_t nbytes)
 {

--- a/crypto/ec/curve448/word.h
+++ b/crypto/ec/curve448/word.h
@@ -63,12 +63,12 @@ typedef int64_t dsword_t;
  * that's handled in common.h: it converts between c448_bool_t and
  * c448_error_t.
  */
-static ossl_inline c448_bool_t mask_to_bool(mask_t m)
+static inline c448_bool_t mask_to_bool(mask_t m)
 {
     return (c448_sword_t)(sword_t)m;
 }
 
-static ossl_inline mask_t bool_to_mask(c448_bool_t m)
+static inline mask_t bool_to_mask(c448_bool_t m)
 {
     /* On most arches this will be optimized to a simple cast. */
     mask_t ret = 0;

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -323,7 +323,7 @@ struct ec_point_st {
                                  * special case */
 };
 
-static ossl_inline int ec_point_is_compat(const EC_POINT *point,
+static inline int ec_point_is_compat(const EC_POINT *point,
                                           const EC_GROUP *group)
 {
     return group->meth == point->meth
@@ -711,7 +711,7 @@ int ossl_ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
 int ossl_ec_point_blind_coordinates(const EC_GROUP *group, EC_POINT *p,
                                     BN_CTX *ctx);
 
-static ossl_inline int ec_point_ladder_pre(const EC_GROUP *group,
+static inline int ec_point_ladder_pre(const EC_GROUP *group,
                                            EC_POINT *r, EC_POINT *s,
                                            EC_POINT *p, BN_CTX *ctx)
 {
@@ -725,7 +725,7 @@ static ossl_inline int ec_point_ladder_pre(const EC_GROUP *group,
     return 1;
 }
 
-static ossl_inline int ec_point_ladder_step(const EC_GROUP *group,
+static inline int ec_point_ladder_step(const EC_GROUP *group,
                                             EC_POINT *r, EC_POINT *s,
                                             EC_POINT *p, BN_CTX *ctx)
 {
@@ -740,7 +740,7 @@ static ossl_inline int ec_point_ladder_step(const EC_GROUP *group,
 
 }
 
-static ossl_inline int ec_point_ladder_post(const EC_GROUP *group,
+static inline int ec_point_ladder_post(const EC_GROUP *group,
                                             EC_POINT *r, EC_POINT *s,
                                             EC_POINT *p, BN_CTX *ctx)
 {

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -724,7 +724,7 @@ static void felem_mul_wrapper(widefelem out, const felem in1, const felem in2)
 # define felem_mul felem_mul_ref
 #endif
 
-static ossl_inline void felem_square_reduce(felem out, const felem in)
+static inline void felem_square_reduce(felem out, const felem in)
 {
     widefelem tmp;
 
@@ -732,7 +732,7 @@ static ossl_inline void felem_square_reduce(felem out, const felem in)
     felem_reduce(out, tmp);
 }
 
-static ossl_inline void felem_mul_reduce(felem out, const felem in1, const felem in2)
+static inline void felem_mul_reduce(felem out, const felem in1, const felem in2)
 {
     widefelem tmp;
 

--- a/crypto/ec/ecp_sm2p256.c
+++ b/crypto/ec/ecp_sm2p256.c
@@ -90,7 +90,7 @@ void ecp_sm2p256_mul(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b);
 /* Modular sqr: r = a ^ 2 mod p */
 void ecp_sm2p256_sqr(BN_ULONG *r, const BN_ULONG *a);
 
-static ossl_inline BN_ULONG is_zeros(const BN_ULONG *a)
+static inline BN_ULONG is_zeros(const BN_ULONG *a)
 {
     BN_ULONG res;
 
@@ -99,7 +99,7 @@ static ossl_inline BN_ULONG is_zeros(const BN_ULONG *a)
     return constant_time_is_zero_64(res);
 }
 
-static ossl_inline int is_equal(const BN_ULONG *a, const BN_ULONG *b)
+static inline int is_equal(const BN_ULONG *a, const BN_ULONG *b)
 {
     BN_ULONG res;
 
@@ -111,7 +111,7 @@ static ossl_inline int is_equal(const BN_ULONG *a, const BN_ULONG *b)
     return constant_time_is_zero_64(res);
 }
 
-static ossl_inline int is_greater(const BN_ULONG *a, const BN_ULONG *b)
+static inline int is_greater(const BN_ULONG *a, const BN_ULONG *b)
 {
     int i;
 
@@ -172,13 +172,13 @@ static ossl_inline int is_greater(const BN_ULONG *a, const BN_ULONG *b)
     } while (0)
 
 /* Modular inverse |out| = |in|^(-1) mod |p|. */
-static ossl_inline void ecp_sm2p256_mod_inverse(BN_ULONG* out,
+static inline void ecp_sm2p256_mod_inverse(BN_ULONG* out,
                                                 const BN_ULONG* in) {
     BN_MOD_INV(out, in, ecp_sm2p256_div_by_2, ecp_sm2p256_sub, def_p);
 }
 
 /* Modular inverse mod order |out| = |in|^(-1) % |ord|. */
-static ossl_inline void ecp_sm2p256_mod_ord_inverse(BN_ULONG* out,
+static inline void ecp_sm2p256_mod_ord_inverse(BN_ULONG* out,
                                                     const BN_ULONG* in) {
     BN_MOD_INV(out, in, ecp_sm2p256_div_by_2_mod_ord, ecp_sm2p256_sub_mod_ord,
                def_ord);

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -635,7 +635,7 @@ static unsigned long decoder_cache_entry_hash(const DECODER_CACHE_ENTRY *cache)
     return hash;
 }
 
-static ossl_inline int nullstrcmp(const char *a, const char *b, int casecmp)
+static inline int nullstrcmp(const char *a, const char *b, int casecmp)
 {
     if (a == NULL || b == NULL) {
         if (a == NULL) {

--- a/crypto/engine/eng_local.h
+++ b/crypto/engine/eng_local.h
@@ -158,7 +158,7 @@ typedef struct st_engine_pile ENGINE_PILE;
 
 DEFINE_LHASH_OF_EX(ENGINE_PILE);
 
-static ossl_unused ossl_inline int eng_struct_ref(ENGINE *e)
+static ossl_unused inline int eng_struct_ref(ENGINE *e)
 {
     int res;
 

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -30,14 +30,14 @@ struct err_state_st {
 };
 # endif
 
-static ossl_inline void err_get_slot(ERR_STATE *es)
+static inline void err_get_slot(ERR_STATE *es)
 {
     es->top = (es->top + 1) % ERR_NUM_ERRORS;
     if (es->top == es->bottom)
         es->bottom = (es->bottom + 1) % ERR_NUM_ERRORS;
 }
 
-static ossl_inline void err_clear_data(ERR_STATE *es, size_t i, int deall)
+static inline void err_clear_data(ERR_STATE *es, size_t i, int deall)
 {
     if (es->err_data_flags[i] & ERR_TXT_MALLOCED) {
         if (deall) {
@@ -56,7 +56,7 @@ static ossl_inline void err_clear_data(ERR_STATE *es, size_t i, int deall)
     }
 }
 
-static ossl_inline void err_set_error(ERR_STATE *es, size_t i,
+static inline void err_set_error(ERR_STATE *es, size_t i,
                                       int lib, int reason)
 {
     es->err_buffer[i] =
@@ -65,7 +65,7 @@ static ossl_inline void err_set_error(ERR_STATE *es, size_t i,
         : ERR_PACK(lib, 0, reason);
 }
 
-static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
+static inline void err_set_debug(ERR_STATE *es, size_t i,
                                       const char *file, int line,
                                       const char *fn)
 {
@@ -90,7 +90,7 @@ static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
         strcpy(es->err_func[i], fn);
 }
 
-static ossl_inline void err_set_data(ERR_STATE *es, size_t i,
+static inline void err_set_data(ERR_STATE *es, size_t i,
                                      void *data, size_t datasz, int flags)
 {
     if ((es->err_data_flags[i] & ERR_TXT_MALLOCED) != 0)
@@ -100,7 +100,7 @@ static ossl_inline void err_set_data(ERR_STATE *es, size_t i,
     es->err_data_flags[i] = flags;
 }
 
-static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
+static inline void err_clear(ERR_STATE *es, size_t i, int deall)
 {
     err_clear_data(es, i, (deall));
     es->err_marks[i] = 0;

--- a/crypto/evp/ec_ctrl.c
+++ b/crypto/evp/ec_ctrl.c
@@ -20,7 +20,7 @@
  * keys.
  */
 
-static ossl_inline
+static inline
 int evp_pkey_ctx_getset_ecdh_param_checks(const EVP_PKEY_CTX *ctx)
 {
     if (ctx == NULL || !EVP_PKEY_CTX_IS_DERIVE_OP(ctx)) {

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -19,17 +19,17 @@
 
 #ifndef OPENSSL_NO_SIV
 
-__owur static ossl_inline uint32_t rotl8(uint32_t x)
+__owur static inline uint32_t rotl8(uint32_t x)
 {
     return (x << 8) | (x >> 24);
 }
 
-__owur static ossl_inline uint32_t rotr8(uint32_t x)
+__owur static inline uint32_t rotr8(uint32_t x)
 {
     return (x >> 8) | (x << 24);
 }
 
-__owur static ossl_inline uint64_t byteswap8(uint64_t x)
+__owur static inline uint64_t byteswap8(uint64_t x)
 {
     uint32_t high = (uint32_t)(x >> 32);
     uint32_t low = (uint32_t)x;
@@ -39,7 +39,7 @@ __owur static ossl_inline uint64_t byteswap8(uint64_t x)
     return ((uint64_t)low) << 32 | (uint64_t)high;
 }
 
-__owur static ossl_inline uint64_t siv128_getword(SIV_BLOCK const *b, size_t i)
+__owur static inline uint64_t siv128_getword(SIV_BLOCK const *b, size_t i)
 {
     DECLARE_IS_ENDIAN;
 
@@ -48,7 +48,7 @@ __owur static ossl_inline uint64_t siv128_getword(SIV_BLOCK const *b, size_t i)
     return b->word[i];
 }
 
-static ossl_inline void siv128_putword(SIV_BLOCK *b, size_t i, uint64_t x)
+static inline void siv128_putword(SIV_BLOCK *b, size_t i, uint64_t x)
 {
     DECLARE_IS_ENDIAN;
 
@@ -58,7 +58,7 @@ static ossl_inline void siv128_putword(SIV_BLOCK *b, size_t i, uint64_t x)
         b->word[i] = x;
 }
 
-static ossl_inline void siv128_xorblock(SIV_BLOCK *x,
+static inline void siv128_xorblock(SIV_BLOCK *x,
                                         SIV_BLOCK const *y)
 {
     x->word[0] ^= y->word[0];
@@ -71,7 +71,7 @@ static ossl_inline void siv128_xorblock(SIV_BLOCK *x,
  * x**128 + x**7 + x**2 + x + 1.
  * Assumes two's-complement arithmetic
  */
-static ossl_inline void siv128_dbl(SIV_BLOCK *b)
+static inline void siv128_dbl(SIV_BLOCK *b)
 {
     uint64_t high = siv128_getword(b, 0);
     uint64_t low = siv128_getword(b, 1);
@@ -86,7 +86,7 @@ static ossl_inline void siv128_dbl(SIV_BLOCK *b)
     siv128_putword(b, 1, low);
 }
 
-__owur static ossl_inline int siv128_do_s2v_p(SIV128_CONTEXT *ctx, SIV_BLOCK *out,
+__owur static inline int siv128_do_s2v_p(SIV128_CONTEXT *ctx, SIV_BLOCK *out,
                                               unsigned char const* in, size_t len)
 {
     SIV_BLOCK t;
@@ -126,7 +126,7 @@ err:
 }
 
 
-__owur static ossl_inline int siv128_do_encrypt(EVP_CIPHER_CTX *ctx, unsigned char *out,
+__owur static inline int siv128_do_encrypt(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                              unsigned char const *in, size_t len,
                                              SIV_BLOCK *icv)
 {

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -45,7 +45,7 @@ static CRYPTO_RWLOCK *ossl_obj_nid_lock = NULL;
 
 static CRYPTO_ONCE ossl_obj_lock_init = CRYPTO_ONCE_STATIC_INIT;
 
-static ossl_inline void objs_free_locks(void)
+static inline void objs_free_locks(void)
 {
     CRYPTO_THREAD_lock_free(ossl_obj_lock);
     ossl_obj_lock = NULL;
@@ -71,7 +71,7 @@ DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
     return 1;
 }
 
-static ossl_inline int ossl_init_added_lock(void)
+static inline int ossl_init_added_lock(void)
 {
 #ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* Make sure we've loaded config before checking for any "added" objects */
@@ -80,7 +80,7 @@ static ossl_inline int ossl_init_added_lock(void)
     return RUN_ONCE(&ossl_obj_lock_init, obj_lock_initialise);
 }
 
-static ossl_inline int ossl_obj_write_lock(int lock)
+static inline int ossl_obj_write_lock(int lock)
 {
     if (!lock)
         return 1;
@@ -89,7 +89,7 @@ static ossl_inline int ossl_obj_write_lock(int lock)
     return CRYPTO_THREAD_write_lock(ossl_obj_lock);
 }
 
-static ossl_inline int ossl_obj_read_lock(int lock)
+static inline int ossl_obj_read_lock(int lock)
 {
     if (!lock)
         return 1;
@@ -98,7 +98,7 @@ static ossl_inline int ossl_obj_read_lock(int lock)
     return CRYPTO_THREAD_read_lock(ossl_obj_lock);
 }
 
-static ossl_inline void ossl_obj_unlock(int lock)
+static inline void ossl_obj_unlock(int lock)
 {
     if (lock)
         CRYPTO_THREAD_unlock(ossl_obj_lock);

--- a/crypto/objects/obj_xref.c
+++ b/crypto/objects/obj_xref.c
@@ -58,7 +58,7 @@ DEFINE_RUN_ONCE_STATIC(o_sig_init)
     return sig_lock != NULL;
 }
 
-static ossl_inline int obj_sig_init(void)
+static inline int obj_sig_init(void)
 {
     return RUN_ONCE(&sig_init, o_sig_init);
 }

--- a/crypto/punycode.c
+++ b/crypto/punycode.c
@@ -57,7 +57,7 @@ static int adapt(unsigned int delta, unsigned int numpoints,
     return k + (((base - tmin + 1) * delta) / (delta + skew));
 }
 
-static ossl_inline int is_basic(unsigned int a)
+static inline int is_basic(unsigned int a)
 {
     return (a < 0x80) ? 1 : 0;
 }
@@ -69,7 +69,7 @@ static ossl_inline int is_basic(unsigned int a)
  * 61..7A (a-z) =  0 to 25, respectively
  * 30..39 (0-9) = 26 to 35, respectively
  */
-static ossl_inline int digit_decoded(const unsigned char a)
+static inline int digit_decoded(const unsigned char a)
 {
     if (a >= 0x41 && a <= 0x5A)
         return a - 0x41;

--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -455,7 +455,7 @@ int ossl_rsa_is_foreign(const RSA *rsa)
     return 0;
 }
 
-static ossl_inline int rsa_bn_dup_check(BIGNUM **out, const BIGNUM *f)
+static inline int rsa_bn_dup_check(BIGNUM **out, const BIGNUM *f)
 {
     if (f != NULL && (*out = BN_dup(f)) == NULL)
         return 0;

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -235,7 +235,7 @@ static const unsigned int c4_690 = 0x12c28f;    /* scale * 4.690 */
 /*
  * Multiply two scaled integers together and rescale the result.
  */
-static ossl_inline uint64_t mul2(uint64_t a, uint64_t b)
+static inline uint64_t mul2(uint64_t a, uint64_t b)
 {
     return a * b / scale;
 }

--- a/crypto/sm4/sm4.c
+++ b/crypto/sm4/sm4.c
@@ -220,12 +220,12 @@ static uint32_t SM4_SBOX_T3[256] = {
     0x4C353579, 0x208080A0, 0x78E5E59D, 0xEDBBBB56, 0x5E7D7D23, 0x3EF8F8C6,
     0xD45F5F8B, 0xC82F2FE7, 0x39E4E4DD, 0x49212168};
 
-static ossl_inline uint32_t rotl(uint32_t a, uint8_t n)
+static inline uint32_t rotl(uint32_t a, uint8_t n)
 {
     return (a << n) | (a >> (32 - n));
 }
 
-static ossl_inline uint32_t load_u32_be(const uint8_t *b, uint32_t n)
+static inline uint32_t load_u32_be(const uint8_t *b, uint32_t n)
 {
     return ((uint32_t)b[4 * n] << 24) |
            ((uint32_t)b[4 * n + 1] << 16) |
@@ -233,7 +233,7 @@ static ossl_inline uint32_t load_u32_be(const uint8_t *b, uint32_t n)
            ((uint32_t)b[4 * n + 3]);
 }
 
-static ossl_inline void store_u32_be(uint32_t v, uint8_t *b)
+static inline void store_u32_be(uint32_t v, uint8_t *b)
 {
     b[0] = (uint8_t)(v >> 24);
     b[1] = (uint8_t)(v >> 16);
@@ -241,7 +241,7 @@ static ossl_inline void store_u32_be(uint32_t v, uint8_t *b)
     b[3] = (uint8_t)(v);
 }
 
-static ossl_inline uint32_t SM4_T_non_lin_sub(uint32_t X)
+static inline uint32_t SM4_T_non_lin_sub(uint32_t X)
 {
     uint32_t t = 0;
 
@@ -253,7 +253,7 @@ static ossl_inline uint32_t SM4_T_non_lin_sub(uint32_t X)
     return t;
 }
 
-static ossl_inline uint32_t SM4_T_slow(uint32_t X)
+static inline uint32_t SM4_T_slow(uint32_t X)
 {
     uint32_t t = SM4_T_non_lin_sub(X);
 
@@ -263,7 +263,7 @@ static ossl_inline uint32_t SM4_T_slow(uint32_t X)
     return t ^ rotl(t, 2) ^ rotl(t, 10) ^ rotl(t, 18) ^ rotl(t, 24);
 }
 
-static ossl_inline uint32_t SM4_T(uint32_t X)
+static inline uint32_t SM4_T(uint32_t X)
 {
     return SM4_SBOX_T0[(uint8_t)(X >> 24)] ^
            SM4_SBOX_T1[(uint8_t)(X >> 16)] ^
@@ -271,7 +271,7 @@ static ossl_inline uint32_t SM4_T(uint32_t X)
            SM4_SBOX_T3[(uint8_t)X];
 }
 
-static ossl_inline uint32_t SM4_key_sub(uint32_t X)
+static inline uint32_t SM4_key_sub(uint32_t X)
 {
     uint32_t t = SM4_T_non_lin_sub(X);
 

--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -171,7 +171,7 @@ void *ossl_sa_get(const OPENSSL_SA *sa, ossl_uintmax_t n)
     return r;
 }
 
-static ossl_inline void **alloc_node(void)
+static inline void **alloc_node(void)
 {
     return OPENSSL_zalloc(SA_BLOCK_MAX * sizeof(void *));
 }

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -13,7 +13,7 @@
 #include "internal/safe_math.h"
 #include <openssl/stack.h>
 #include <errno.h>
-#include <openssl/e_os2.h>      /* For ossl_inline */
+#include <openssl/e_os2.h>      /* For inline */
 
 OSSL_SAFE_MATH_SIGNED(int, int)
 
@@ -156,7 +156,7 @@ OPENSSL_STACK *OPENSSL_sk_new(OPENSSL_sk_compfunc c)
  *
  * 3/2 and 8/5 have nice power of two shifts, so seem like a good choice.
  */
-static ossl_inline int compute_growth(int target, int current)
+static inline int compute_growth(int target, int current)
 {
     int err = 0;
 
@@ -281,7 +281,7 @@ int OPENSSL_sk_insert(OPENSSL_STACK *st, const void *data, int loc)
     return st->num;
 }
 
-static ossl_inline void *internal_delete(OPENSSL_STACK *st, int loc)
+static inline void *internal_delete(OPENSSL_STACK *st, int loc)
 {
     const void *ret = st->data[loc];
 

--- a/crypto/thread/internal.c
+++ b/crypto/thread/internal.c
@@ -16,7 +16,7 @@
 
 #if !defined(OPENSSL_NO_DEFAULT_THREAD_POOL)
 
-static ossl_inline uint64_t _ossl_get_avail_threads(OSSL_LIB_CTX_THREADS *tdata)
+static inline uint64_t _ossl_get_avail_threads(OSSL_LIB_CTX_THREADS *tdata)
 {
     /* assumes that tdata->lock is taken */
     return tdata->max_threads - tdata->active_threads;
@@ -101,7 +101,7 @@ int ossl_crypto_thread_clean(void *vhandle)
 
 #else
 
-ossl_inline uint64_t ossl_get_avail_threads(OSSL_LIB_CTX *ctx)
+inline uint64_t ossl_get_avail_threads(OSSL_LIB_CTX *ctx)
 {
     return 0;
 }

--- a/doc/man7/provider-asym_cipher.pod
+++ b/doc/man7/provider-asym_cipher.pod
@@ -66,7 +66,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_asym_cipher_newctx() has these:
 
  typedef void *(OSSL_FUNC_asym_cipher_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_asym_cipher_newctx_fn
+ static inline OSSL_FUNC_asym_cipher_newctx_fn
      OSSL_FUNC_asym_cipher_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -138,7 +138,7 @@ For example, the "function" core_gettable_params() has these:
 
  typedef OSSL_PARAM *
      (OSSL_FUNC_core_gettable_params_fn)(const OSSL_CORE_HANDLE *handle);
- static ossl_inline OSSL_NAME_core_gettable_params_fn
+ static inline OSSL_NAME_core_gettable_params_fn
      OSSL_FUNC_core_gettable_params(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as
@@ -930,28 +930,28 @@ This relies on a few things existing in F<openssl/core_dispatch.h>:
 
  #define OSSL_FUNC_BAR_NEWCTX      1
  typedef void *(OSSL_FUNC_bar_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_bar_newctx(const OSSL_DISPATCH *opf)
+ static inline OSSL_FUNC_bar_newctx(const OSSL_DISPATCH *opf)
  { return (OSSL_FUNC_bar_newctx_fn *)opf->function; }
 
  #define OSSL_FUNC_BAR_FREECTX     2
  typedef void (OSSL_FUNC_bar_freectx_fn)(void *ctx);
- static ossl_inline OSSL_FUNC_bar_freectx(const OSSL_DISPATCH *opf)
+ static inline OSSL_FUNC_bar_freectx(const OSSL_DISPATCH *opf)
  { return (OSSL_FUNC_bar_freectx_fn *)opf->function; }
 
  #define OSSL_FUNC_BAR_INIT        3
  typedef void *(OSSL_FUNC_bar_init_fn)(void *ctx);
- static ossl_inline OSSL_FUNC_bar_init(const OSSL_DISPATCH *opf)
+ static inline OSSL_FUNC_bar_init(const OSSL_DISPATCH *opf)
  { return (OSSL_FUNC_bar_init_fn *)opf->function; }
 
  #define OSSL_FUNC_BAR_UPDATE      4
  typedef void *(OSSL_FUNC_bar_update_fn)(void *ctx,
                                        unsigned char *in, size_t inl);
- static ossl_inline OSSL_FUNC_bar_update(const OSSL_DISPATCH *opf)
+ static inline OSSL_FUNC_bar_update(const OSSL_DISPATCH *opf)
  { return (OSSL_FUNC_bar_update_fn *)opf->function; }
 
  #define OSSL_FUNC_BAR_FINAL       5
  typedef void *(OSSL_FUNC_bar_final_fn)(void *ctx);
- static ossl_inline OSSL_FUNC_bar_final(const OSSL_DISPATCH *opf)
+ static inline OSSL_FUNC_bar_final(const OSSL_DISPATCH *opf)
  { return (OSSL_FUNC_bar_final_fn *)opf->function; }
 
 =head1 SEE ALSO

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -75,7 +75,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_cipher_newctx() has these:
 
  typedef void *(OSSL_FUNC_cipher_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_cipher_newctx_fn
+ static inline OSSL_FUNC_cipher_newctx_fn
      OSSL_FUNC_cipher_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-decoder.pod
+++ b/doc/man7/provider-decoder.pod
@@ -83,7 +83,7 @@ For example, the "function" OSSL_FUNC_decoder_decode() has these:
                                    int selection,
                                    OSSL_CALLBACK *data_cb, void *data_cbarg,
                                    OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg);
- static ossl_inline OSSL_FUNC_decoder_decode_fn*
+ static inline OSSL_FUNC_decoder_decode_fn*
      OSSL_FUNC_decoder_decode(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -67,7 +67,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_digest_newctx() has these:
 
  typedef void *(OSSL_FUNC_digest_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_digest_newctx_fn
+ static inline OSSL_FUNC_digest_newctx_fn
      OSSL_FUNC_digest_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-encoder.pod
+++ b/doc/man7/provider-encoder.pod
@@ -100,7 +100,7 @@ For example, the "function" OSSL_FUNC_encoder_encode() has these:
                                    const OSSL_PARAM obj_abstract[],
                                    int selection,
                                    OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg);
- static ossl_inline OSSL_FUNC_encoder_encode_fn
+ static inline OSSL_FUNC_encoder_encode_fn
      OSSL_FUNC_encoder_encode(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-kdf.pod
+++ b/doc/man7/provider-kdf.pod
@@ -59,7 +59,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_kdf_newctx() has these:
 
  typedef void *(OSSL_FUNC_kdf_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_kdf_newctx_fn
+ static inline OSSL_FUNC_kdf_newctx_fn
      OSSL_FUNC_kdf_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> array entries are identified by numbers that are provided as

--- a/doc/man7/provider-kem.pod
+++ b/doc/man7/provider-kem.pod
@@ -68,7 +68,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_kem_newctx() has these:
 
  typedef void *(OSSL_FUNC_kem_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_kem_newctx_fn
+ static inline OSSL_FUNC_kem_newctx_fn
      OSSL_FUNC_kem_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -60,7 +60,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_keyexch_newctx() has these:
 
  typedef void *(OSSL_FUNC_keyexch_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_keyexch_newctx_fn
+ static inline OSSL_FUNC_keyexch_newctx_fn
      OSSL_FUNC_keyexch_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -86,7 +86,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_keymgmt_new() has these:
 
  typedef void *(OSSL_FUNC_keymgmt_new_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_keymgmt_new_fn
+ static inline OSSL_FUNC_keymgmt_new_fn
      OSSL_FUNC_keymgmt_new(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -60,7 +60,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_mac_newctx() has these:
 
  typedef void *(OSSL_FUNC_mac_newctx_fn)(void *provctx);
- static ossl_inline OSSL_FUNC_mac_newctx_fn
+ static inline OSSL_FUNC_mac_newctx_fn
      OSSL_FUNC_mac_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -105,7 +105,7 @@ B<OSSL_FUNC_{name}>.
 For example, the "function" OSSL_FUNC_signature_newctx() has these:
 
  typedef void *(OSSL_FUNC_signature_newctx_fn)(void *provctx, const char *propq);
- static ossl_inline OSSL_FUNC_signature_newctx_fn
+ static inline OSSL_FUNC_signature_newctx_fn
      OSSL_FUNC_signature_newctx(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as

--- a/doc/man7/provider-storemgmt.pod
+++ b/doc/man7/provider-storemgmt.pod
@@ -64,7 +64,7 @@ For example, the "function" OSSL_FUNC_store_attach() has these:
 
  typedef void *(OSSL_FUNC_store_attach_fn)(void *provctx,
                                            OSSL_CORE_BIO * bio);
- static ossl_inline OSSL_FUNC_store_attach_fn
+ static inline OSSL_FUNC_store_attach_fn
      OSSL_FUNC_store_attach(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as macros

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -104,22 +104,22 @@ static cbc_handles cbc_handle[] = {{AES_KEY_SIZE_128, NULL},
                                     {AES_KEY_SIZE_192, NULL},
                                     {AES_KEY_SIZE_256, NULL}};
 
-static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
+static inline int io_setup(unsigned n, aio_context_t *ctx)
 {
     return syscall(__NR_io_setup, n, ctx);
 }
 
-static ossl_inline int eventfd(int n)
+static inline int eventfd(int n)
 {
     return syscall(__NR_eventfd2, n, 0);
 }
 
-static ossl_inline int io_destroy(aio_context_t ctx)
+static inline int io_destroy(aio_context_t ctx)
 {
     return syscall(__NR_io_destroy, ctx);
 }
 
-static ossl_inline int io_read(aio_context_t ctx, long n, struct iocb **iocb)
+static inline int io_read(aio_context_t ctx, long n, struct iocb **iocb)
 {
     return syscall(__NR_io_submit, ctx, n, iocb);
 }
@@ -131,7 +131,7 @@ struct __timespec32
   __kernel_long_t tv_nsec;
 };
 
-static ossl_inline int io_getevents(aio_context_t ctx, long min, long max,
+static inline int io_getevents(aio_context_t ctx, long min, long max,
                                struct io_event *events,
                                struct timespec *timeout)
 {
@@ -403,7 +403,7 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
     return 1;
 }
 
-static ossl_inline void afalg_set_op_sk(struct cmsghdr *cmsg,
+static inline void afalg_set_op_sk(struct cmsghdr *cmsg,
                                    const ALG_OP_TYPE op)
 {
     cmsg->cmsg_level = SOL_ALG;
@@ -425,7 +425,7 @@ static void afalg_set_iv_sk(struct cmsghdr *cmsg, const unsigned char *iv,
     memcpy(aiv->iv, iv, len);
 }
 
-static ossl_inline int afalg_set_key(afalg_ctx *actx, const unsigned char *key,
+static inline int afalg_set_key(afalg_ctx *actx, const unsigned char *key,
                                 const int klen)
 {
     int ret;

--- a/include/crypto/sparse_array.h
+++ b/include/crypto/sparse_array.h
@@ -22,34 +22,34 @@ extern "C" {
 
 # define DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, ctype) \
     SPARSE_ARRAY_OF(type); \
-    static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) * \
+    static ossl_unused inline SPARSE_ARRAY_OF(type) * \
         ossl_sa_##type##_new(void) \
     { \
         return (SPARSE_ARRAY_OF(type) *)ossl_sa_new(); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     ossl_sa_##type##_free(SPARSE_ARRAY_OF(type) *sa) \
     { \
         ossl_sa_free((OPENSSL_SA *)sa); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     ossl_sa_##type##_free_leaves(SPARSE_ARRAY_OF(type) *sa) \
     { \
         ossl_sa_free_leaves((OPENSSL_SA *)sa); \
     } \
-    static ossl_unused ossl_inline size_t \
+    static ossl_unused inline size_t \
     ossl_sa_##type##_num(const SPARSE_ARRAY_OF(type) *sa) \
     { \
         return ossl_sa_num((OPENSSL_SA *)sa); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) *sa, \
                            void (*leaf)(ossl_uintmax_t, type *)) \
     { \
         ossl_sa_doall((OPENSSL_SA *)sa, \
                       (void (*)(ossl_uintmax_t, void *))leaf); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
                                void (*leaf)(ossl_uintmax_t, type *, void *), \
                                void *arg) \
@@ -57,12 +57,12 @@ extern "C" {
         ossl_sa_doall_arg((OPENSSL_SA *)sa, \
                           (void (*)(ossl_uintmax_t, void *, void *))leaf, arg); \
     } \
-    static ossl_unused ossl_inline ctype \
+    static ossl_unused inline ctype \
     *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, ossl_uintmax_t n) \
     { \
         return (type *)ossl_sa_get((OPENSSL_SA *)sa, n); \
     } \
-    static ossl_unused ossl_inline int \
+    static ossl_unused inline int \
     ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa, \
                          ossl_uintmax_t n, ctype *val) \
     { \

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -15,7 +15,7 @@
 # include <string.h>
 # include "openssl/configuration.h"
 
-# include "internal/e_os.h" /* ossl_inline in many files */
+# include "internal/e_os.h" /* inline in many files */
 # include "internal/nelem.h"
 
 # if defined(__GNUC__) || defined(__clang__)
@@ -40,7 +40,7 @@
 # ifdef NDEBUG
 #  define ossl_assert(x) ossl_likely((x) != 0)
 # else
-__owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
+__owur static inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)
 {
     if (!expr)
@@ -184,7 +184,7 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                            (c)[1]=(unsigned char)(((l)>> 8)&0xff), \
                            (c)[2]=(unsigned char)(((l)    )&0xff)),(c)+=3)
 
-static ossl_inline int ossl_ends_with_dirsep(const char *path)
+static inline int ossl_ends_with_dirsep(const char *path)
 {
     if (*path != '\0')
         path += strlen(path) - 1;
@@ -198,7 +198,7 @@ static ossl_inline int ossl_ends_with_dirsep(const char *path)
     return *path == '/';
 }
 
-static ossl_inline char ossl_determine_dirsep(const char *path)
+static inline char ossl_determine_dirsep(const char *path)
 {
     if (ossl_ends_with_dirsep(path))
         return '\0';
@@ -212,7 +212,7 @@ static ossl_inline char ossl_determine_dirsep(const char *path)
 # endif
 }
 
-static ossl_inline int ossl_is_absolute_path(const char *path)
+static inline int ossl_is_absolute_path(const char *path)
 {
 # if defined __VMS
     if (strchr(path, ':') != NULL

--- a/include/internal/constant_time.h
+++ b/include/internal/constant_time.h
@@ -13,7 +13,7 @@
 
 # include <stdlib.h>
 # include <string.h>
-# include <openssl/e_os2.h>              /* For 'inline' */
+# include <openssl/e_os2.h>              /* For 'int64_t' */
 
 /*-
  * The boolean methods return a bitmask of all ones (0xff...f) for true

--- a/include/internal/constant_time.h
+++ b/include/internal/constant_time.h
@@ -13,7 +13,7 @@
 
 # include <stdlib.h>
 # include <string.h>
-# include <openssl/e_os2.h>              /* For 'ossl_inline' */
+# include <openssl/e_os2.h>              /* For 'inline' */
 
 /*-
  * The boolean methods return a bitmask of all ones (0xff...f) for true
@@ -30,45 +30,45 @@
  */
 
 /* Returns the given value with the MSB copied to all the other bits. */
-static ossl_inline unsigned int constant_time_msb(unsigned int a);
+static inline unsigned int constant_time_msb(unsigned int a);
 /* Convenience method for uint32_t. */
-static ossl_inline uint32_t constant_time_msb_32(uint32_t a);
+static inline uint32_t constant_time_msb_32(uint32_t a);
 /* Convenience method for uint64_t. */
-static ossl_inline uint64_t constant_time_msb_64(uint64_t a);
+static inline uint64_t constant_time_msb_64(uint64_t a);
 
 /* Returns 0xff..f if a < b and 0 otherwise. */
-static ossl_inline unsigned int constant_time_lt(unsigned int a,
+static inline unsigned int constant_time_lt(unsigned int a,
                                                  unsigned int b);
 /* Convenience method for getting an 8-bit mask. */
-static ossl_inline unsigned char constant_time_lt_8(unsigned int a,
+static inline unsigned char constant_time_lt_8(unsigned int a,
                                                     unsigned int b);
 /* Convenience method for uint64_t. */
-static ossl_inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b);
+static inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b);
 
 /* Returns 0xff..f if a >= b and 0 otherwise. */
-static ossl_inline unsigned int constant_time_ge(unsigned int a,
+static inline unsigned int constant_time_ge(unsigned int a,
                                                  unsigned int b);
 /* Convenience method for getting an 8-bit mask. */
-static ossl_inline unsigned char constant_time_ge_8(unsigned int a,
+static inline unsigned char constant_time_ge_8(unsigned int a,
                                                     unsigned int b);
 
 /* Returns 0xff..f if a == 0 and 0 otherwise. */
-static ossl_inline unsigned int constant_time_is_zero(unsigned int a);
+static inline unsigned int constant_time_is_zero(unsigned int a);
 /* Convenience method for getting an 8-bit mask. */
-static ossl_inline unsigned char constant_time_is_zero_8(unsigned int a);
+static inline unsigned char constant_time_is_zero_8(unsigned int a);
 /* Convenience method for getting a 32-bit mask. */
-static ossl_inline uint32_t constant_time_is_zero_32(uint32_t a);
+static inline uint32_t constant_time_is_zero_32(uint32_t a);
 
 /* Returns 0xff..f if a == b and 0 otherwise. */
-static ossl_inline unsigned int constant_time_eq(unsigned int a,
+static inline unsigned int constant_time_eq(unsigned int a,
                                                  unsigned int b);
 /* Convenience method for getting an 8-bit mask. */
-static ossl_inline unsigned char constant_time_eq_8(unsigned int a,
+static inline unsigned char constant_time_eq_8(unsigned int a,
                                                     unsigned int b);
 /* Signed integers. */
-static ossl_inline unsigned int constant_time_eq_int(int a, int b);
+static inline unsigned int constant_time_eq_int(int a, int b);
 /* Convenience method for getting an 8-bit mask. */
-static ossl_inline unsigned char constant_time_eq_int_8(int a, int b);
+static inline unsigned char constant_time_eq_int_8(int a, int b);
 
 /*-
  * Returns (mask & a) | (~mask & b).
@@ -77,144 +77,144 @@ static ossl_inline unsigned char constant_time_eq_int_8(int a, int b);
  * the select methods return either |a| (if |mask| is nonzero) or |b|
  * (if |mask| is zero).
  */
-static ossl_inline unsigned int constant_time_select(unsigned int mask,
+static inline unsigned int constant_time_select(unsigned int mask,
                                                      unsigned int a,
                                                      unsigned int b);
 /* Convenience method for unsigned chars. */
-static ossl_inline unsigned char constant_time_select_8(unsigned char mask,
+static inline unsigned char constant_time_select_8(unsigned char mask,
                                                         unsigned char a,
                                                         unsigned char b);
 
 /* Convenience method for uint32_t. */
-static ossl_inline uint32_t constant_time_select_32(uint32_t mask, uint32_t a,
+static inline uint32_t constant_time_select_32(uint32_t mask, uint32_t a,
                                                     uint32_t b);
 
 /* Convenience method for uint64_t. */
-static ossl_inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,
+static inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,
                                                     uint64_t b);
 /* Convenience method for signed integers. */
-static ossl_inline int constant_time_select_int(unsigned int mask, int a,
+static inline int constant_time_select_int(unsigned int mask, int a,
                                                 int b);
 
 
-static ossl_inline unsigned int constant_time_msb(unsigned int a)
+static inline unsigned int constant_time_msb(unsigned int a)
 {
     return 0 - (a >> (sizeof(a) * 8 - 1));
 }
 
 
-static ossl_inline uint32_t constant_time_msb_32(uint32_t a)
+static inline uint32_t constant_time_msb_32(uint32_t a)
 {
     return 0 - (a >> 31);
 }
 
-static ossl_inline uint64_t constant_time_msb_64(uint64_t a)
+static inline uint64_t constant_time_msb_64(uint64_t a)
 {
     return 0 - (a >> 63);
 }
 
-static ossl_inline size_t constant_time_msb_s(size_t a)
+static inline size_t constant_time_msb_s(size_t a)
 {
     return 0 - (a >> (sizeof(a) * 8 - 1));
 }
 
-static ossl_inline unsigned int constant_time_lt(unsigned int a,
+static inline unsigned int constant_time_lt(unsigned int a,
                                                  unsigned int b)
 {
     return constant_time_msb(a ^ ((a ^ b) | ((a - b) ^ b)));
 }
 
-static ossl_inline size_t constant_time_lt_s(size_t a, size_t b)
+static inline size_t constant_time_lt_s(size_t a, size_t b)
 {
     return constant_time_msb_s(a ^ ((a ^ b) | ((a - b) ^ b)));
 }
 
-static ossl_inline unsigned char constant_time_lt_8(unsigned int a,
+static inline unsigned char constant_time_lt_8(unsigned int a,
                                                     unsigned int b)
 {
     return (unsigned char)constant_time_lt(a, b);
 }
 
-static ossl_inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b)
+static inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b)
 {
     return constant_time_msb_64(a ^ ((a ^ b) | ((a - b) ^ b)));
 }
 
-static ossl_inline unsigned int constant_time_ge(unsigned int a,
+static inline unsigned int constant_time_ge(unsigned int a,
                                                  unsigned int b)
 {
     return ~constant_time_lt(a, b);
 }
 
-static ossl_inline size_t constant_time_ge_s(size_t a, size_t b)
+static inline size_t constant_time_ge_s(size_t a, size_t b)
 {
     return ~constant_time_lt_s(a, b);
 }
 
-static ossl_inline unsigned char constant_time_ge_8(unsigned int a,
+static inline unsigned char constant_time_ge_8(unsigned int a,
                                                     unsigned int b)
 {
     return (unsigned char)constant_time_ge(a, b);
 }
 
-static ossl_inline unsigned char constant_time_ge_8_s(size_t a, size_t b)
+static inline unsigned char constant_time_ge_8_s(size_t a, size_t b)
 {
     return (unsigned char)constant_time_ge_s(a, b);
 }
 
-static ossl_inline unsigned int constant_time_is_zero(unsigned int a)
+static inline unsigned int constant_time_is_zero(unsigned int a)
 {
     return constant_time_msb(~a & (a - 1));
 }
 
-static ossl_inline size_t constant_time_is_zero_s(size_t a)
+static inline size_t constant_time_is_zero_s(size_t a)
 {
     return constant_time_msb_s(~a & (a - 1));
 }
 
-static ossl_inline unsigned char constant_time_is_zero_8(unsigned int a)
+static inline unsigned char constant_time_is_zero_8(unsigned int a)
 {
     return (unsigned char)constant_time_is_zero(a);
 }
 
-static ossl_inline uint32_t constant_time_is_zero_32(uint32_t a)
+static inline uint32_t constant_time_is_zero_32(uint32_t a)
 {
     return constant_time_msb_32(~a & (a - 1));
 }
 
-static ossl_inline uint64_t constant_time_is_zero_64(uint64_t a)
+static inline uint64_t constant_time_is_zero_64(uint64_t a)
 {
     return constant_time_msb_64(~a & (a - 1));
 }
 
-static ossl_inline unsigned int constant_time_eq(unsigned int a,
+static inline unsigned int constant_time_eq(unsigned int a,
                                                  unsigned int b)
 {
     return constant_time_is_zero(a ^ b);
 }
 
-static ossl_inline size_t constant_time_eq_s(size_t a, size_t b)
+static inline size_t constant_time_eq_s(size_t a, size_t b)
 {
     return constant_time_is_zero_s(a ^ b);
 }
 
-static ossl_inline unsigned char constant_time_eq_8(unsigned int a,
+static inline unsigned char constant_time_eq_8(unsigned int a,
                                                     unsigned int b)
 {
     return (unsigned char)constant_time_eq(a, b);
 }
 
-static ossl_inline unsigned char constant_time_eq_8_s(size_t a, size_t b)
+static inline unsigned char constant_time_eq_8_s(size_t a, size_t b)
 {
     return (unsigned char)constant_time_eq_s(a, b);
 }
 
-static ossl_inline unsigned int constant_time_eq_int(int a, int b)
+static inline unsigned int constant_time_eq_int(int a, int b)
 {
     return constant_time_eq((unsigned)(a), (unsigned)(b));
 }
 
-static ossl_inline unsigned char constant_time_eq_int_8(int a, int b)
+static inline unsigned char constant_time_eq_int_8(int a, int b)
 {
     return constant_time_eq_8((unsigned)(a), (unsigned)(b));
 }
@@ -226,7 +226,7 @@ static ossl_inline unsigned char constant_time_eq_int_8(int a, int b)
  * statements, which avoids the recognition of the select
  * and turning it into a conditional load or branch.
  */
-static ossl_inline unsigned int value_barrier(unsigned int a)
+static inline unsigned int value_barrier(unsigned int a)
 {
 #if !defined(OPENSSL_NO_ASM) && defined(__GNUC__)
     unsigned int r;
@@ -238,7 +238,7 @@ static ossl_inline unsigned int value_barrier(unsigned int a)
 }
 
 /* Convenience method for uint32_t. */
-static ossl_inline uint32_t value_barrier_32(uint32_t a)
+static inline uint32_t value_barrier_32(uint32_t a)
 {
 #if !defined(OPENSSL_NO_ASM) && defined(__GNUC__)
     uint32_t r;
@@ -250,7 +250,7 @@ static ossl_inline uint32_t value_barrier_32(uint32_t a)
 }
 
 /* Convenience method for uint64_t. */
-static ossl_inline uint64_t value_barrier_64(uint64_t a)
+static inline uint64_t value_barrier_64(uint64_t a)
 {
 #if !defined(OPENSSL_NO_ASM) && defined(__GNUC__)
     uint64_t r;
@@ -262,7 +262,7 @@ static ossl_inline uint64_t value_barrier_64(uint64_t a)
 }
 
 /* Convenience method for size_t. */
-static ossl_inline size_t value_barrier_s(size_t a)
+static inline size_t value_barrier_s(size_t a)
 {
 #if !defined(OPENSSL_NO_ASM) && defined(__GNUC__)
     size_t r;
@@ -273,46 +273,46 @@ static ossl_inline size_t value_barrier_s(size_t a)
     return r;
 }
 
-static ossl_inline unsigned int constant_time_select(unsigned int mask,
+static inline unsigned int constant_time_select(unsigned int mask,
                                                      unsigned int a,
                                                      unsigned int b)
 {
     return (value_barrier(mask) & a) | (value_barrier(~mask) & b);
 }
 
-static ossl_inline size_t constant_time_select_s(size_t mask,
+static inline size_t constant_time_select_s(size_t mask,
                                                  size_t a,
                                                  size_t b)
 {
     return (value_barrier_s(mask) & a) | (value_barrier_s(~mask) & b);
 }
 
-static ossl_inline unsigned char constant_time_select_8(unsigned char mask,
+static inline unsigned char constant_time_select_8(unsigned char mask,
                                                         unsigned char a,
                                                         unsigned char b)
 {
     return (unsigned char)constant_time_select(mask, a, b);
 }
 
-static ossl_inline int constant_time_select_int(unsigned int mask, int a,
+static inline int constant_time_select_int(unsigned int mask, int a,
                                                 int b)
 {
     return (int)constant_time_select(mask, (unsigned)(a), (unsigned)(b));
 }
 
-static ossl_inline int constant_time_select_int_s(size_t mask, int a, int b)
+static inline int constant_time_select_int_s(size_t mask, int a, int b)
 {
     return (int)constant_time_select((unsigned)mask, (unsigned)(a),
                                       (unsigned)(b));
 }
 
-static ossl_inline uint32_t constant_time_select_32(uint32_t mask, uint32_t a,
+static inline uint32_t constant_time_select_32(uint32_t mask, uint32_t a,
                                                     uint32_t b)
 {
     return (value_barrier_32(mask) & a) | (value_barrier_32(~mask) & b);
 }
 
-static ossl_inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,
+static inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,
                                                     uint64_t b)
 {
     return (value_barrier_64(mask) & a) | (value_barrier_64(~mask) & b);
@@ -328,7 +328,7 @@ static ossl_inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,
  *     *b = tmp;
  * }
  */
-static ossl_inline void constant_time_cond_swap_32(uint32_t mask, uint32_t *a,
+static inline void constant_time_cond_swap_32(uint32_t mask, uint32_t *a,
                                                    uint32_t *b)
 {
     uint32_t xor = *a ^ *b;
@@ -348,7 +348,7 @@ static ossl_inline void constant_time_cond_swap_32(uint32_t mask, uint32_t *a,
  *     *b = tmp;
  * }
  */
-static ossl_inline void constant_time_cond_swap_64(uint64_t mask, uint64_t *a,
+static inline void constant_time_cond_swap_64(uint64_t mask, uint64_t *a,
                                                    uint64_t *b)
 {
     uint64_t xor = *a ^ *b;
@@ -370,7 +370,7 @@ static ossl_inline void constant_time_cond_swap_64(uint64_t mask, uint64_t *a,
  *     memcpy(b, tmp);
  * }
  */
-static ossl_inline void constant_time_cond_swap_buff(unsigned char mask,
+static inline void constant_time_cond_swap_buff(unsigned char mask,
                                                      unsigned char *a,
                                                      unsigned char *b,
                                                      size_t len)
@@ -391,7 +391,7 @@ static ossl_inline void constant_time_cond_swap_buff(unsigned char mask,
  * Copies row number idx into out. rowsize and numrows are not considered
  * private.
  */
-static ossl_inline void constant_time_lookup(void *out,
+static inline void constant_time_lookup(void *out,
                                              const void *table,
                                              size_t rowsize,
                                              size_t numrows,

--- a/include/internal/event_queue.h
+++ b/include/internal/event_queue.h
@@ -57,31 +57,31 @@ int ossl_event_queue_add(OSSL_EVENT_QUEUE *queue, OSSL_EVENT *event,
 /*
  * Utility functions to extract event fields
  */
-static ossl_unused ossl_inline
+static ossl_unused inline
 uint32_t ossl_event_get_type(const OSSL_EVENT *event)
 {
     return event->type;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 uint32_t ossl_event_get_priority(const OSSL_EVENT *event)
 {
     return event->priority;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_event_get_when(const OSSL_EVENT *event)
 {
     return event->when;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 void *ossl_event_get0_ctx(const OSSL_EVENT *event)
 {
     return event->ctx;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 void *ossl_event_get0_payload(const OSSL_EVENT *event, size_t *length)
 {
     if (length != NULL)

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -52,7 +52,7 @@ typedef struct tls_enable ktls_crypto_info_t;
  * FreeBSD does not require any additional steps to enable KTLS before
  * setting keys.
  */
-static ossl_inline int ktls_enable(int fd)
+static inline int ktls_enable(int fd)
 {
     return 1;
 }
@@ -67,7 +67,7 @@ static ossl_inline int ktls_enable(int fd)
  * as using TLS.  If successful, then data received for this socket will
  * be authenticated and decrypted using the tls_en provided here.
  */
-static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *tls_en, int is_tx)
+static inline int ktls_start(int fd, ktls_crypto_info_t *tls_en, int is_tx)
 {
     if (is_tx)
         return setsockopt(fd, IPPROTO_TCP, TCP_TXTLS_ENABLE,
@@ -81,7 +81,7 @@ static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *tls_en, int is_tx)
 }
 
 /* Not supported on FreeBSD */
-static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
+static inline int ktls_enable_tx_zerocopy_sendfile(int fd)
 {
     return 0;
 }
@@ -93,7 +93,7 @@ static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
  * the entire record is pushed to TCP. It is impossible to send a partial
  * record using this control message.
  */
-static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
+static inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
                                               const void *data, size_t length)
 {
     struct msghdr msg = { 0 };
@@ -121,7 +121,7 @@ static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
 
 #   ifdef OPENSSL_NO_KTLS_RX
 
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+static inline int ktls_read_record(int fd, void *data, size_t length)
 {
     return -1;
 }
@@ -135,7 +135,7 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
  * with the TLS record such as an invalid header, invalid padding, or
  * authentication failure recvmsg() will fail with an error.
  */
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+static inline int ktls_read_record(int fd, void *data, size_t length)
 {
     struct msghdr msg = { 0 };
     int cmsg_len = sizeof(struct tls_get_record);
@@ -196,7 +196,7 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
  * KTLS enables the sendfile system call to send data from a file over
  * TLS.
  */
-static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
+static inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
                                               size_t size, int flags)
 {
     off_t sbytes = 0;
@@ -286,7 +286,7 @@ typedef struct tls_crypto_info_all ktls_crypto_info_t;
  * processing of SOL_TLS socket options. All other functionality remains the
  * same.
  */
-static ossl_inline int ktls_enable(int fd)
+static inline int ktls_enable(int fd)
 {
     return setsockopt(fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls")) ? 0 : 1;
 }
@@ -299,14 +299,14 @@ static ossl_inline int ktls_enable(int fd)
  * If successful, then data received using this socket will be decrypted,
  * authenticated and decapsulated using the crypto_info provided here.
  */
-static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *crypto_info,
+static inline int ktls_start(int fd, ktls_crypto_info_t *crypto_info,
                                   int is_tx)
 {
     return setsockopt(fd, SOL_TLS, is_tx ? TLS_TX : TLS_RX,
                       crypto_info, crypto_info->tls_crypto_info_len) ? 0 : 1;
 }
 
-static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
+static inline int ktls_enable_tx_zerocopy_sendfile(int fd)
 {
 #ifndef OPENSSL_NO_KTLS_ZC_TX
     int enable = 1;
@@ -325,7 +325,7 @@ static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
  * the entire record is pushed to TCP. It is impossible to send a partial
  * record using this control message.
  */
-static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
+static inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
                                               const void *data, size_t length)
 {
     struct msghdr msg;
@@ -359,7 +359,7 @@ static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
  * KTLS enables the sendfile system call to send data from a file over TLS.
  * @flags are ignored on Linux. (placeholder for FreeBSD sendfile)
  * */
-static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off, size_t size, int flags)
+static inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off, size_t size, int flags)
 {
     return sendfile(s, fd, &off, size);
 }
@@ -367,7 +367,7 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off, size_t s
 #   ifdef OPENSSL_NO_KTLS_RX
 
 
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+static inline int ktls_read_record(int fd, void *data, size_t length)
 {
     return -1;
 }
@@ -380,7 +380,7 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
  * returning only the plaintext data or an error on failure.
  * We add the TLS record header here to satisfy routines in rec_layer_s3.c
  */
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+static inline int ktls_read_record(int fd, void *data, size_t length)
 {
     struct msghdr msg;
     struct cmsghdr *cmsg;

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -66,42 +66,42 @@
     }                                                                       \
 
 # define DEFINE_LIST_OF_IMPL(name, type)                                    \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_init(OSSL_LIST(name) *list)                          \
     {                                                                       \
         memset(list, 0, sizeof(*list));                                     \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_init_elem(type *elem)                                \
     {                                                                       \
         memset(&elem->ossl_list_ ## name, 0,                                \
                sizeof(elem->ossl_list_ ## name));                           \
     }                                                                       \
-    static ossl_unused ossl_inline int                                      \
+    static ossl_unused inline int                                      \
     ossl_list_##name##_is_empty(const OSSL_LIST(name) *list)                \
     {                                                                       \
         return list->num_elems == 0;                                        \
     }                                                                       \
-    static ossl_unused ossl_inline size_t                                   \
+    static ossl_unused inline size_t                                   \
     ossl_list_##name##_num(const OSSL_LIST(name) *list)                     \
     {                                                                       \
         return list->num_elems;                                             \
     }                                                                       \
-    static ossl_unused ossl_inline type *                                   \
+    static ossl_unused inline type *                                   \
     ossl_list_##name##_head(const OSSL_LIST(name) *list)                    \
     {                                                                       \
         assert(list->alpha == NULL                                          \
                || list->alpha->ossl_list_ ## name.list == list);            \
         return list->alpha;                                                 \
     }                                                                       \
-    static ossl_unused ossl_inline type *                                   \
+    static ossl_unused inline type *                                   \
     ossl_list_##name##_tail(const OSSL_LIST(name) *list)                    \
     {                                                                       \
         assert(list->omega == NULL                                          \
                || list->omega->ossl_list_ ## name.list == list);            \
         return list->omega;                                                 \
     }                                                                       \
-    static ossl_unused ossl_inline type *                                   \
+    static ossl_unused inline type *                                   \
     ossl_list_##name##_next(const type *elem)                               \
     {                                                                       \
         assert(elem->ossl_list_ ## name.next == NULL                        \
@@ -109,7 +109,7 @@
                       ->ossl_list_ ## name.prev == elem);                   \
         return elem->ossl_list_ ## name.next;                               \
     }                                                                       \
-    static ossl_unused ossl_inline type *                                   \
+    static ossl_unused inline type *                                   \
     ossl_list_##name##_prev(const type *elem)                               \
     {                                                                       \
         assert(elem->ossl_list_ ## name.prev == NULL                        \
@@ -117,7 +117,7 @@
                       ->ossl_list_ ## name.next == elem);                   \
         return elem->ossl_list_ ## name.prev;                               \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_remove(OSSL_LIST(name) *list, type *elem)            \
     {                                                                       \
         assert(elem->ossl_list_ ## name.list == list);                      \
@@ -136,7 +136,7 @@
         memset(&elem->ossl_list_ ## name, 0,                                \
                sizeof(elem->ossl_list_ ## name));                           \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_insert_head(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
         assert(elem->ossl_list_ ## name.list == NULL);                      \
@@ -150,7 +150,7 @@
             list->omega = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_insert_tail(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
         assert(elem->ossl_list_ ## name.list == NULL);                      \
@@ -164,7 +164,7 @@
             list->alpha = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_insert_before(OSSL_LIST(name) *list, type *e,        \
                                      type *elem)                            \
     {                                                                       \
@@ -179,7 +179,7 @@
             list->alpha = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_list_##name##_insert_after(OSSL_LIST(name) *list, type *e,         \
                                     type *elem)                             \
     {                                                                       \

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -27,7 +27,7 @@ typedef struct {
 } PACKET;
 
 /* Internal unchecked shorthand; don't use outside this file. */
-static ossl_inline void packet_forward(PACKET *pkt, size_t len)
+static inline void packet_forward(PACKET *pkt, size_t len)
 {
     pkt->curr += len;
     pkt->remaining -= len;
@@ -36,7 +36,7 @@ static ossl_inline void packet_forward(PACKET *pkt, size_t len)
 /*
  * Returns the number of bytes remaining to be read in the PACKET
  */
-static ossl_inline size_t PACKET_remaining(const PACKET *pkt)
+static inline size_t PACKET_remaining(const PACKET *pkt)
 {
     return pkt->remaining;
 }
@@ -47,7 +47,7 @@ static ossl_inline size_t PACKET_remaining(const PACKET *pkt)
  * Specifically, we use PACKET_end() to verify that a d2i_... call
  * has consumed the entire packet contents.
  */
-static ossl_inline const unsigned char *PACKET_end(const PACKET *pkt)
+static inline const unsigned char *PACKET_end(const PACKET *pkt)
 {
     return pkt->curr + pkt->remaining;
 }
@@ -56,7 +56,7 @@ static ossl_inline const unsigned char *PACKET_end(const PACKET *pkt)
  * Returns a pointer to the PACKET's current position.
  * For use in non-PACKETized APIs.
  */
-static ossl_inline const unsigned char *PACKET_data(const PACKET *pkt)
+static inline const unsigned char *PACKET_data(const PACKET *pkt)
 {
     return pkt->curr;
 }
@@ -66,7 +66,7 @@ static ossl_inline const unsigned char *PACKET_data(const PACKET *pkt)
  * copy of the data so |buf| must be present for the whole time that the PACKET
  * is being used.
  */
-__owur static ossl_inline int PACKET_buf_init(PACKET *pkt,
+__owur static inline int PACKET_buf_init(PACKET *pkt,
                                               const unsigned char *buf,
                                               size_t len)
 {
@@ -80,7 +80,7 @@ __owur static ossl_inline int PACKET_buf_init(PACKET *pkt,
 }
 
 /* Initialize a PACKET to hold zero bytes. */
-static ossl_inline void PACKET_null_init(PACKET *pkt)
+static inline void PACKET_null_init(PACKET *pkt)
 {
     pkt->curr = NULL;
     pkt->remaining = 0;
@@ -91,7 +91,7 @@ static ossl_inline void PACKET_null_init(PACKET *pkt)
  * bytes read from |ptr|. Returns 0 otherwise (lengths or contents not equal).
  * If lengths are equal, performs the comparison in constant time.
  */
-__owur static ossl_inline int PACKET_equal(const PACKET *pkt, const void *ptr,
+__owur static inline int PACKET_equal(const PACKET *pkt, const void *ptr,
                                            size_t num)
 {
     if (PACKET_remaining(pkt) != num)
@@ -104,7 +104,7 @@ __owur static ossl_inline int PACKET_equal(const PACKET *pkt, const void *ptr,
  * Data is not copied: the |subpkt| packet will share its underlying buffer with
  * the original |pkt|, so data wrapped by |pkt| must outlive the |subpkt|.
  */
-__owur static ossl_inline int PACKET_peek_sub_packet(const PACKET *pkt,
+__owur static inline int PACKET_peek_sub_packet(const PACKET *pkt,
                                                      PACKET *subpkt, size_t len)
 {
     if (PACKET_remaining(pkt) < len)
@@ -118,7 +118,7 @@ __owur static ossl_inline int PACKET_peek_sub_packet(const PACKET *pkt,
  * copied: the |subpkt| packet will share its underlying buffer with the
  * original |pkt|, so data wrapped by |pkt| must outlive the |subpkt|.
  */
-__owur static ossl_inline int PACKET_get_sub_packet(PACKET *pkt,
+__owur static inline int PACKET_get_sub_packet(PACKET *pkt,
                                                     PACKET *subpkt, size_t len)
 {
     if (!PACKET_peek_sub_packet(pkt, subpkt, len))
@@ -133,7 +133,7 @@ __owur static ossl_inline int PACKET_get_sub_packet(PACKET *pkt,
  * Peek ahead at 2 bytes in network order from |pkt| and store the value in
  * |*data|
  */
-__owur static ossl_inline int PACKET_peek_net_2(const PACKET *pkt,
+__owur static inline int PACKET_peek_net_2(const PACKET *pkt,
                                                 unsigned int *data)
 {
     if (PACKET_remaining(pkt) < 2)
@@ -147,7 +147,7 @@ __owur static ossl_inline int PACKET_peek_net_2(const PACKET *pkt,
 
 /* Equivalent of n2s */
 /* Get 2 bytes in network order from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_get_net_2(PACKET *pkt, unsigned int *data)
+__owur static inline int PACKET_get_net_2(PACKET *pkt, unsigned int *data)
 {
     if (!PACKET_peek_net_2(pkt, data))
         return 0;
@@ -158,7 +158,7 @@ __owur static ossl_inline int PACKET_get_net_2(PACKET *pkt, unsigned int *data)
 }
 
 /* Same as PACKET_get_net_2() but for a size_t */
-__owur static ossl_inline int PACKET_get_net_2_len(PACKET *pkt, size_t *data)
+__owur static inline int PACKET_get_net_2_len(PACKET *pkt, size_t *data)
 {
     unsigned int i;
     int ret = PACKET_get_net_2(pkt, &i);
@@ -173,7 +173,7 @@ __owur static ossl_inline int PACKET_get_net_2_len(PACKET *pkt, size_t *data)
  * Peek ahead at 3 bytes in network order from |pkt| and store the value in
  * |*data|
  */
-__owur static ossl_inline int PACKET_peek_net_3(const PACKET *pkt,
+__owur static inline int PACKET_peek_net_3(const PACKET *pkt,
                                                 unsigned long *data)
 {
     if (PACKET_remaining(pkt) < 3)
@@ -188,7 +188,7 @@ __owur static ossl_inline int PACKET_peek_net_3(const PACKET *pkt,
 
 /* Equivalent of n2l3 */
 /* Get 3 bytes in network order from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_get_net_3(PACKET *pkt, unsigned long *data)
+__owur static inline int PACKET_get_net_3(PACKET *pkt, unsigned long *data)
 {
     if (!PACKET_peek_net_3(pkt, data))
         return 0;
@@ -199,7 +199,7 @@ __owur static ossl_inline int PACKET_get_net_3(PACKET *pkt, unsigned long *data)
 }
 
 /* Same as PACKET_get_net_3() but for a size_t */
-__owur static ossl_inline int PACKET_get_net_3_len(PACKET *pkt, size_t *data)
+__owur static inline int PACKET_get_net_3_len(PACKET *pkt, size_t *data)
 {
     unsigned long i;
     int ret = PACKET_get_net_3(pkt, &i);
@@ -214,7 +214,7 @@ __owur static ossl_inline int PACKET_get_net_3_len(PACKET *pkt, size_t *data)
  * Peek ahead at 4 bytes in network order from |pkt| and store the value in
  * |*data|
  */
-__owur static ossl_inline int PACKET_peek_net_4(const PACKET *pkt,
+__owur static inline int PACKET_peek_net_4(const PACKET *pkt,
                                                 unsigned long *data)
 {
     if (PACKET_remaining(pkt) < 4)
@@ -232,7 +232,7 @@ __owur static ossl_inline int PACKET_peek_net_4(const PACKET *pkt,
  * Peek ahead at 8 bytes in network order from |pkt| and store the value in
  * |*data|
  */
-__owur static ossl_inline int PACKET_peek_net_8(const PACKET *pkt,
+__owur static inline int PACKET_peek_net_8(const PACKET *pkt,
                                                 uint64_t *data)
 {
     if (PACKET_remaining(pkt) < 8)
@@ -252,7 +252,7 @@ __owur static ossl_inline int PACKET_peek_net_8(const PACKET *pkt,
 
 /* Equivalent of n2l */
 /* Get 4 bytes in network order from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_get_net_4(PACKET *pkt, unsigned long *data)
+__owur static inline int PACKET_get_net_4(PACKET *pkt, unsigned long *data)
 {
     if (!PACKET_peek_net_4(pkt, data))
         return 0;
@@ -263,7 +263,7 @@ __owur static ossl_inline int PACKET_get_net_4(PACKET *pkt, unsigned long *data)
 }
 
 /* Same as PACKET_get_net_4() but for a size_t */
-__owur static ossl_inline int PACKET_get_net_4_len(PACKET *pkt, size_t *data)
+__owur static inline int PACKET_get_net_4_len(PACKET *pkt, size_t *data)
 {
     unsigned long i;
     int ret = PACKET_get_net_4(pkt, &i);
@@ -275,7 +275,7 @@ __owur static ossl_inline int PACKET_get_net_4_len(PACKET *pkt, size_t *data)
 }
 
 /* Get 8 bytes in network order from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_get_net_8(PACKET *pkt, uint64_t *data)
+__owur static inline int PACKET_get_net_8(PACKET *pkt, uint64_t *data)
 {
     if (!PACKET_peek_net_8(pkt, data))
         return 0;
@@ -286,7 +286,7 @@ __owur static ossl_inline int PACKET_get_net_8(PACKET *pkt, uint64_t *data)
 }
 
 /* Peek ahead at 1 byte from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_peek_1(const PACKET *pkt,
+__owur static inline int PACKET_peek_1(const PACKET *pkt,
                                             unsigned int *data)
 {
     if (!PACKET_remaining(pkt))
@@ -298,7 +298,7 @@ __owur static ossl_inline int PACKET_peek_1(const PACKET *pkt,
 }
 
 /* Get 1 byte from |pkt| and store the value in |*data| */
-__owur static ossl_inline int PACKET_get_1(PACKET *pkt, unsigned int *data)
+__owur static inline int PACKET_get_1(PACKET *pkt, unsigned int *data)
 {
     if (!PACKET_peek_1(pkt, data))
         return 0;
@@ -309,7 +309,7 @@ __owur static ossl_inline int PACKET_get_1(PACKET *pkt, unsigned int *data)
 }
 
 /* Same as PACKET_get_1() but for a size_t */
-__owur static ossl_inline int PACKET_get_1_len(PACKET *pkt, size_t *data)
+__owur static inline int PACKET_get_1_len(PACKET *pkt, size_t *data)
 {
     unsigned int i;
     int ret = PACKET_get_1(pkt, &i);
@@ -324,7 +324,7 @@ __owur static ossl_inline int PACKET_get_1_len(PACKET *pkt, size_t *data)
  * Peek ahead at 4 bytes in reverse network order from |pkt| and store the value
  * in |*data|
  */
-__owur static ossl_inline int PACKET_peek_4(const PACKET *pkt,
+__owur static inline int PACKET_peek_4(const PACKET *pkt,
                                             unsigned long *data)
 {
     if (PACKET_remaining(pkt) < 4)
@@ -343,7 +343,7 @@ __owur static ossl_inline int PACKET_peek_4(const PACKET *pkt,
  * Get 4 bytes in reverse network order from |pkt| and store the value in
  * |*data|
  */
-__owur static ossl_inline int PACKET_get_4(PACKET *pkt, unsigned long *data)
+__owur static inline int PACKET_get_4(PACKET *pkt, unsigned long *data)
 {
     if (!PACKET_peek_4(pkt, data))
         return 0;
@@ -359,7 +359,7 @@ __owur static ossl_inline int PACKET_get_4(PACKET *pkt, unsigned long *data)
  * caller should not free this data directly (it will be freed when the
  * underlying buffer gets freed
  */
-__owur static ossl_inline int PACKET_peek_bytes(const PACKET *pkt,
+__owur static inline int PACKET_peek_bytes(const PACKET *pkt,
                                                 const unsigned char **data,
                                                 size_t len)
 {
@@ -377,7 +377,7 @@ __owur static ossl_inline int PACKET_peek_bytes(const PACKET *pkt,
  * not free this data directly (it will be freed when the underlying buffer gets
  * freed
  */
-__owur static ossl_inline int PACKET_get_bytes(PACKET *pkt,
+__owur static inline int PACKET_get_bytes(PACKET *pkt,
                                                const unsigned char **data,
                                                size_t len)
 {
@@ -390,7 +390,7 @@ __owur static ossl_inline int PACKET_get_bytes(PACKET *pkt,
 }
 
 /* Peek ahead at |len| bytes from |pkt| and copy them to |data| */
-__owur static ossl_inline int PACKET_peek_copy_bytes(const PACKET *pkt,
+__owur static inline int PACKET_peek_copy_bytes(const PACKET *pkt,
                                                      unsigned char *data,
                                                      size_t len)
 {
@@ -406,7 +406,7 @@ __owur static ossl_inline int PACKET_peek_copy_bytes(const PACKET *pkt,
  * Read |len| bytes from |pkt| and copy them to |data|.
  * The caller is responsible for ensuring that |data| can hold |len| bytes.
  */
-__owur static ossl_inline int PACKET_copy_bytes(PACKET *pkt,
+__owur static inline int PACKET_copy_bytes(PACKET *pkt,
                                                 unsigned char *data, size_t len)
 {
     if (!PACKET_peek_copy_bytes(pkt, data, len))
@@ -424,7 +424,7 @@ __owur static ossl_inline int PACKET_copy_bytes(PACKET *pkt,
  * Does not forward PACKET position (because it is typically the last thing
  * done with a given PACKET).
  */
-__owur static ossl_inline int PACKET_copy_all(const PACKET *pkt,
+__owur static inline int PACKET_copy_all(const PACKET *pkt,
                                               unsigned char *dest,
                                               size_t dest_len, size_t *len)
 {
@@ -446,7 +446,7 @@ __owur static ossl_inline int PACKET_copy_all(const PACKET *pkt,
  * Does not forward PACKET position (because it is typically the last thing
  * done with a given PACKET).
  */
-__owur static ossl_inline int PACKET_memdup(const PACKET *pkt,
+__owur static inline int PACKET_memdup(const PACKET *pkt,
                                             unsigned char **data, size_t *len)
 {
     size_t length;
@@ -478,7 +478,7 @@ __owur static ossl_inline int PACKET_memdup(const PACKET *pkt,
  * Does not forward PACKET position (because it is typically the last thing done
  * with a given PACKET).
  */
-__owur static ossl_inline int PACKET_strndup(const PACKET *pkt, char **data)
+__owur static inline int PACKET_strndup(const PACKET *pkt, char **data)
 {
     OPENSSL_free(*data);
 
@@ -488,13 +488,13 @@ __owur static ossl_inline int PACKET_strndup(const PACKET *pkt, char **data)
 }
 
 /* Returns 1 if |pkt| contains at least one 0-byte, 0 otherwise. */
-static ossl_inline int PACKET_contains_zero_byte(const PACKET *pkt)
+static inline int PACKET_contains_zero_byte(const PACKET *pkt)
 {
     return memchr(pkt->curr, 0, pkt->remaining) != NULL;
 }
 
 /* Move the current reading position forward |len| bytes */
-__owur static ossl_inline int PACKET_forward(PACKET *pkt, size_t len)
+__owur static inline int PACKET_forward(PACKET *pkt, size_t len)
 {
     if (PACKET_remaining(pkt) < len)
         return 0;
@@ -511,7 +511,7 @@ __owur static ossl_inline int PACKET_forward(PACKET *pkt, size_t len)
  * the original |pkt|, so data wrapped by |pkt| must outlive the |subpkt|.
  * Upon failure, the original |pkt| and |subpkt| are not modified.
  */
-__owur static ossl_inline int PACKET_get_length_prefixed_1(PACKET *pkt,
+__owur static inline int PACKET_get_length_prefixed_1(PACKET *pkt,
                                                            PACKET *subpkt)
 {
     unsigned int length;
@@ -533,7 +533,7 @@ __owur static ossl_inline int PACKET_get_length_prefixed_1(PACKET *pkt,
  * Like PACKET_get_length_prefixed_1, but additionally, fails when there are
  * leftover bytes in |pkt|.
  */
-__owur static ossl_inline int PACKET_as_length_prefixed_1(PACKET *pkt,
+__owur static inline int PACKET_as_length_prefixed_1(PACKET *pkt,
                                                           PACKET *subpkt)
 {
     unsigned int length;
@@ -559,7 +559,7 @@ __owur static ossl_inline int PACKET_as_length_prefixed_1(PACKET *pkt,
  * the original |pkt|, so data wrapped by |pkt| must outlive the |subpkt|.
  * Upon failure, the original |pkt| and |subpkt| are not modified.
  */
-__owur static ossl_inline int PACKET_get_length_prefixed_2(PACKET *pkt,
+__owur static inline int PACKET_get_length_prefixed_2(PACKET *pkt,
                                                            PACKET *subpkt)
 {
     unsigned int length;
@@ -582,7 +582,7 @@ __owur static ossl_inline int PACKET_get_length_prefixed_2(PACKET *pkt,
  * Like PACKET_get_length_prefixed_2, but additionally, fails when there are
  * leftover bytes in |pkt|.
  */
-__owur static ossl_inline int PACKET_as_length_prefixed_2(PACKET *pkt,
+__owur static inline int PACKET_as_length_prefixed_2(PACKET *pkt,
                                                           PACKET *subpkt)
 {
     unsigned int length;
@@ -609,7 +609,7 @@ __owur static ossl_inline int PACKET_as_length_prefixed_2(PACKET *pkt,
  * the original |pkt|, so data wrapped by |pkt| must outlive the |subpkt|.
  * Upon failure, the original |pkt| and |subpkt| are not modified.
  */
-__owur static ossl_inline int PACKET_get_length_prefixed_3(PACKET *pkt,
+__owur static inline int PACKET_get_length_prefixed_3(PACKET *pkt,
                                                            PACKET *subpkt)
 {
     unsigned long length;

--- a/include/internal/priority_queue.h
+++ b/include/internal/priority_queue.h
@@ -18,50 +18,50 @@
 
 # define DEFINE_PRIORITY_QUEUE_OF_INTERNAL(type, ctype)                     \
     typedef struct ossl_priority_queue_st_ ## type PRIORITY_QUEUE_OF(type); \
-    static ossl_unused ossl_inline PRIORITY_QUEUE_OF(type) *                \
+    static ossl_unused inline PRIORITY_QUEUE_OF(type) *                \
     ossl_pqueue_##type##_new(int (*compare)(const ctype *, const ctype *))  \
     {                                                                       \
         return (PRIORITY_QUEUE_OF(type) *)ossl_pqueue_new(                  \
                     (int (*)(const void *, const void *))compare);          \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_pqueue_##type##_free(PRIORITY_QUEUE_OF(type) *pq)                  \
     {                                                                       \
         ossl_pqueue_free((OSSL_PQUEUE *)pq);                                \
     }                                                                       \
-    static ossl_unused ossl_inline void                                     \
+    static ossl_unused inline void                                     \
     ossl_pqueue_##type##_pop_free(PRIORITY_QUEUE_OF(type) *pq,              \
                                   void (*freefunc)(ctype *))                \
     {                                                                       \
         ossl_pqueue_pop_free((OSSL_PQUEUE *)pq, (void (*)(void *))freefunc);\
     }                                                                       \
-    static ossl_unused ossl_inline int                                      \
+    static ossl_unused inline int                                      \
     ossl_pqueue_##type##_reserve(PRIORITY_QUEUE_OF(type) *pq, size_t n)     \
     {                                                                       \
         return ossl_pqueue_reserve((OSSL_PQUEUE *)pq, n);                   \
     }                                                                       \
-    static ossl_unused ossl_inline size_t                                   \
+    static ossl_unused inline size_t                                   \
     ossl_pqueue_##type##_num(const PRIORITY_QUEUE_OF(type) *pq)             \
     {                                                                       \
         return ossl_pqueue_num((OSSL_PQUEUE *)pq);                          \
     }                                                                       \
-    static ossl_unused ossl_inline int                                      \
+    static ossl_unused inline int                                      \
     ossl_pqueue_##type##_push(PRIORITY_QUEUE_OF(type) *pq,                  \
                               ctype *data, size_t *elem)                    \
     {                                                                       \
         return ossl_pqueue_push((OSSL_PQUEUE *)pq, (void *)data, elem);     \
     }                                                                       \
-    static ossl_unused ossl_inline ctype *                                  \
+    static ossl_unused inline ctype *                                  \
     ossl_pqueue_##type##_peek(const PRIORITY_QUEUE_OF(type) *pq)            \
     {                                                                       \
         return (type *)ossl_pqueue_peek((OSSL_PQUEUE *)pq);                 \
     }                                                                       \
-    static ossl_unused ossl_inline ctype *                                  \
+    static ossl_unused inline ctype *                                  \
     ossl_pqueue_##type##_pop(PRIORITY_QUEUE_OF(type) *pq)                   \
     {                                                                       \
         return (type *)ossl_pqueue_pop((OSSL_PQUEUE *)pq);                  \
     }                                                                       \
-    static ossl_unused ossl_inline ctype *                                  \
+    static ossl_unused inline ctype *                                  \
     ossl_pqueue_##type##_remove(PRIORITY_QUEUE_OF(type) *pq,                \
                                 size_t elem)                                \
     {                                                                       \

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -199,26 +199,26 @@ typedef struct {
 
 #  ifdef OPENSSL_THREADS
 
-static ossl_unused ossl_inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, 
+static ossl_unused inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, 
                                                  int *ret)
 {
     return CRYPTO_atomic_add(&refcnt->val, 1, ret, refcnt->lock);
 }
 
-static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
                                                    int *ret)
 {
     return CRYPTO_atomic_add(&refcnt->val, -1, ret, refcnt->lock);
 }
 
-static ossl_unused ossl_inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
                                                    int *ret)
 {
     return CRYPTO_atomic_load_int(&refcnt->val, ret, refcnt->lock);
 }
 
 #   define CRYPTO_NEW_FREE_DEFINED  1
-static ossl_unused ossl_inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int n)
+static ossl_unused inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int n)
 {
     refcnt->val = n;
     refcnt->lock = CRYPTO_THREAD_lock_new();
@@ -229,7 +229,7 @@ static ossl_unused ossl_inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int 
     return 1;
 }
 
-static ossl_unused ossl_inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)                                  \
+static ossl_unused inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)                                  \
 {
     if (refcnt != NULL)
         CRYPTO_THREAD_lock_free(refcnt->lock);
@@ -237,7 +237,7 @@ static ossl_unused ossl_inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)   
 
 #  else     /* OPENSSL_THREADS */
 
-static ossl_unused ossl_inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, 
+static ossl_unused inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, 
                                                  int *ret)
 {
     refcnt->val++;
@@ -245,7 +245,7 @@ static ossl_unused ossl_inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt,
     return 1;
 }
 
-static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
                                                    int *ret)
 {
     refcnt->val--;
@@ -253,7 +253,7 @@ static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
     return 1;
 }
 
-static ossl_unused ossl_inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
                                                    int *ret)
 {
     *ret = refcnt->val;
@@ -264,13 +264,13 @@ static ossl_unused ossl_inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
 # endif
 
 # ifndef CRYPTO_NEW_FREE_DEFINED
-static ossl_unused ossl_inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int n)
+static ossl_unused inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int n)
 {
     refcnt->val = n;
     return 1;
 }
 
-static ossl_unused ossl_inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)                                  \
+static ossl_unused inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)                                  \
 {
 }
 # endif /* CRYPTO_NEW_FREE_DEFINED */

--- a/include/internal/ring_buf.h
+++ b/include/internal/ring_buf.h
@@ -11,7 +11,7 @@
 # define OSSL_INTERNAL_RING_BUF_H
 # pragma once
 
-# include <openssl/e_os2.h>              /* For 'ossl_inline' */
+# include <openssl/e_os2.h>              /* For 'inline' */
 # include "internal/safe_math.h"
 
 /*
@@ -44,7 +44,7 @@ OSSL_SAFE_MATH_UNSIGNED(u64, uint64_t)
 
 #define MAX_OFFSET   (((uint64_t)1) << 62) /* QUIC-imposed limit */
 
-static ossl_inline int ring_buf_init(struct ring_buf *r)
+static inline int ring_buf_init(struct ring_buf *r)
 {
     r->start = NULL;
     r->alloc = 0;
@@ -52,7 +52,7 @@ static ossl_inline int ring_buf_init(struct ring_buf *r)
     return 1;
 }
 
-static ossl_inline void ring_buf_destroy(struct ring_buf *r, int cleanse)
+static inline void ring_buf_destroy(struct ring_buf *r, int cleanse)
 {
     if (cleanse)
         OPENSSL_clear_free(r->start, r->alloc);
@@ -62,17 +62,17 @@ static ossl_inline void ring_buf_destroy(struct ring_buf *r, int cleanse)
     r->alloc = 0;
 }
 
-static ossl_inline size_t ring_buf_used(struct ring_buf *r)
+static inline size_t ring_buf_used(struct ring_buf *r)
 {
     return (size_t)(r->head_offset - r->ctail_offset);
 }
 
-static ossl_inline size_t ring_buf_avail(struct ring_buf *r)
+static inline size_t ring_buf_avail(struct ring_buf *r)
 {
     return r->alloc - ring_buf_used(r);
 }
 
-static ossl_inline int ring_buf_write_at(struct ring_buf *r,
+static inline int ring_buf_write_at(struct ring_buf *r,
                                          uint64_t logical_offset,
                                          const unsigned char *buf,
                                          size_t buf_len)
@@ -110,7 +110,7 @@ static ossl_inline int ring_buf_write_at(struct ring_buf *r,
     return 1;
 }
 
-static ossl_inline size_t ring_buf_push(struct ring_buf *r,
+static inline size_t ring_buf_push(struct ring_buf *r,
                                         const unsigned char *buf,
                                         size_t buf_len)
 {
@@ -143,7 +143,7 @@ static ossl_inline size_t ring_buf_push(struct ring_buf *r,
     return pushed;
 }
 
-static ossl_inline const unsigned char *ring_buf_get_ptr(const struct ring_buf *r,
+static inline const unsigned char *ring_buf_get_ptr(const struct ring_buf *r,
                                                          uint64_t logical_offset,
                                                          size_t *max_len)
 {
@@ -169,7 +169,7 @@ static ossl_inline const unsigned char *ring_buf_get_ptr(const struct ring_buf *
  *
  * The ring buffer state is not changed.
  */
-static ossl_inline int ring_buf_get_buf_at(const struct ring_buf *r,
+static inline int ring_buf_get_buf_at(const struct ring_buf *r,
                                            uint64_t logical_offset,
                                            const unsigned char **buf,
                                            size_t *buf_len)
@@ -196,7 +196,7 @@ static ossl_inline int ring_buf_get_buf_at(const struct ring_buf *r,
     return 1;
 }
 
-static ossl_inline void ring_buf_cpop_range(struct ring_buf *r,
+static inline void ring_buf_cpop_range(struct ring_buf *r,
                                             uint64_t start, uint64_t end,
                                             int cleanse)
 {
@@ -228,7 +228,7 @@ static ossl_inline void ring_buf_cpop_range(struct ring_buf *r,
         r->head_offset = r->ctail_offset;
 }
 
-static ossl_inline int ring_buf_resize(struct ring_buf *r, size_t num_bytes,
+static inline int ring_buf_resize(struct ring_buf *r, size_t num_bytes,
                                        int cleanse)
 {
     struct ring_buf rnew = {0};

--- a/include/internal/safe_math.h
+++ b/include/internal/safe_math.h
@@ -11,7 +11,7 @@
 # define OSSL_INTERNAL_SAFE_MATH_H
 # pragma once
 
-# include <openssl/e_os2.h>              /* For 'ossl_inline' */
+# include <openssl/e_os2.h>              /* For 'inline' */
 
 # ifndef OPENSSL_NO_BUILTIN_OVERFLOW_CHECKING
 #  ifdef __has_builtin
@@ -30,7 +30,7 @@
  */
 # if has(__builtin_add_overflow)
 #  define OSSL_SAFE_MATH_ADDS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_add_ ## type_name(type a,       \
+    static inline ossl_unused type safe_add_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -43,7 +43,7 @@
     }
 
 #  define OSSL_SAFE_MATH_ADDU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_add_ ## type_name(type a,       \
+    static inline ossl_unused type safe_add_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -57,7 +57,7 @@
 
 # else  /* has(__builtin_add_overflow) */
 #  define OSSL_SAFE_MATH_ADDS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_add_ ## type_name(type a,       \
+    static inline ossl_unused type safe_add_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -71,7 +71,7 @@
     }
 
 #  define OSSL_SAFE_MATH_ADDU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_add_ ## type_name(type a,       \
+    static inline ossl_unused type safe_add_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -86,7 +86,7 @@
  */
 # if has(__builtin_sub_overflow)
 #  define OSSL_SAFE_MATH_SUBS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_sub_ ## type_name(type a,       \
+    static inline ossl_unused type safe_sub_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -100,7 +100,7 @@
 
 # else  /* has(__builtin_sub_overflow) */
 #  define OSSL_SAFE_MATH_SUBS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_sub_ ## type_name(type a,       \
+    static inline ossl_unused type safe_sub_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -116,7 +116,7 @@
 # endif /* has(__builtin_sub_overflow) */
 
 # define OSSL_SAFE_MATH_SUBU(type_name, type) \
-    static ossl_inline ossl_unused type safe_sub_ ## type_name(type a,       \
+    static inline ossl_unused type safe_sub_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -130,7 +130,7 @@
  */
 # if has(__builtin_mul_overflow)
 #  define OSSL_SAFE_MATH_MULS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_mul_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mul_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -143,7 +143,7 @@
     }
 
 #  define OSSL_SAFE_MATH_MULU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_mul_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mul_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -157,7 +157,7 @@
 
 # else  /* has(__builtin_mul_overflow) */
 #  define OSSL_SAFE_MATH_MULS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_mul_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mul_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -179,7 +179,7 @@
     }
 
 #  define OSSL_SAFE_MATH_MULU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_mul_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mul_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -193,7 +193,7 @@
  * Safe division helpers
  */
 # define OSSL_SAFE_MATH_DIVS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_div_ ## type_name(type a,       \
+    static inline ossl_unused type safe_div_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -209,7 +209,7 @@
     }
 
 # define OSSL_SAFE_MATH_DIVU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_div_ ## type_name(type a,       \
+    static inline ossl_unused type safe_div_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -223,7 +223,7 @@
  * Safe modulus helpers
  */
 # define OSSL_SAFE_MATH_MODS(type_name, type, min, max) \
-    static ossl_inline ossl_unused type safe_mod_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mod_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -239,7 +239,7 @@
     }
 
 # define OSSL_SAFE_MATH_MODU(type_name, type) \
-    static ossl_inline ossl_unused type safe_mod_ ## type_name(type a,       \
+    static inline ossl_unused type safe_mod_ ## type_name(type a,       \
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
@@ -253,7 +253,7 @@
  * Safe negation helpers
  */
 # define OSSL_SAFE_MATH_NEGS(type_name, type, min) \
-    static ossl_inline ossl_unused type safe_neg_ ## type_name(type a,       \
+    static inline ossl_unused type safe_neg_ ## type_name(type a,       \
                                                                int *err)     \
     {                                                                        \
         if (a != min)                                                        \
@@ -263,7 +263,7 @@
     }
 
 # define OSSL_SAFE_MATH_NEGU(type_name, type) \
-    static ossl_inline ossl_unused type safe_neg_ ## type_name(type a,       \
+    static inline ossl_unused type safe_neg_ ## type_name(type a,       \
                                                                int *err)     \
     {                                                                        \
         if (a == 0)                                                          \
@@ -276,7 +276,7 @@
  * Safe absolute value helpers
  */
 # define OSSL_SAFE_MATH_ABSS(type_name, type, min) \
-    static ossl_inline ossl_unused type safe_abs_ ## type_name(type a,       \
+    static inline ossl_unused type safe_abs_ ## type_name(type a,       \
                                                                int *err)     \
     {                                                                        \
         if (a != min)                                                        \
@@ -286,7 +286,7 @@
     }
 
 # define OSSL_SAFE_MATH_ABSU(type_name, type) \
-    static ossl_inline ossl_unused type safe_abs_ ## type_name(type a,       \
+    static inline ossl_unused type safe_abs_ ## type_name(type a,       \
                                                                int *err)     \
     {                                                                        \
         return a;                                                            \
@@ -315,7 +315,7 @@
  * The algorithm used is not perfect but it should be "good enough".
  */
 # define OSSL_SAFE_MATH_MULDIVS(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_muldiv_ ## type_name(type a,    \
+    static inline ossl_unused type safe_muldiv_ ## type_name(type a,    \
                                                                   type b,    \
                                                                   type c,    \
                                                                   int *err)  \
@@ -344,7 +344,7 @@
     }
 
 # define OSSL_SAFE_MATH_MULDIVU(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_muldiv_ ## type_name(type a,    \
+    static inline ossl_unused type safe_muldiv_ ## type_name(type a,    \
                                                                   type b,    \
                                                                   type c,    \
                                                                   int *err)  \
@@ -376,7 +376,7 @@
  * If you *know* that b != 0, then it's safe to ignore err.
  */
 #define OSSL_SAFE_MATH_DIV_ROUND_UP(type_name, type, max) \
-    static ossl_inline ossl_unused type safe_div_round_up_ ## type_name      \
+    static inline ossl_unused type safe_div_round_up_ ## type_name      \
         (type a, type b, int *errp)                                          \
     {                                                                        \
         type x;                                                              \

--- a/include/internal/time.h
+++ b/include/internal/time.h
@@ -53,7 +53,7 @@ typedef struct {
 OSSL_SAFE_MATH_UNSIGNED(time, uint64_t)
 
 /* Convert a tick count into a time */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_ticks2time(uint64_t ticks)
 {
     OSSL_TIME r;
@@ -63,7 +63,7 @@ OSSL_TIME ossl_ticks2time(uint64_t ticks)
 }
 
 /* Convert a time to a tick count */
-static ossl_unused ossl_inline
+static ossl_unused inline
 uint64_t ossl_time2ticks(OSSL_TIME t)
 {
     return t.t;
@@ -73,13 +73,13 @@ uint64_t ossl_time2ticks(OSSL_TIME t)
 OSSL_TIME ossl_time_now(void);
 
 /* The beginning and end of the time range */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_zero(void)
 {
     return ossl_ticks2time(0);
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_infinite(void)
 {
     return ossl_ticks2time(~(uint64_t)0);
@@ -87,7 +87,7 @@ OSSL_TIME ossl_time_infinite(void)
 
 
 /* Convert time to timeval */
-static ossl_unused ossl_inline
+static ossl_unused inline
 struct timeval ossl_time_to_timeval(OSSL_TIME t)
 {
     struct timeval tv;
@@ -111,7 +111,7 @@ struct timeval ossl_time_to_timeval(OSSL_TIME t)
 }
 
 /* Convert timeval to time */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_from_timeval(struct timeval tv)
 {
     OSSL_TIME t;
@@ -123,14 +123,14 @@ OSSL_TIME ossl_time_from_timeval(struct timeval tv)
 }
 
 /* Convert OSSL_TIME to time_t */
-static ossl_unused ossl_inline
+static ossl_unused inline
 time_t ossl_time_to_time_t(OSSL_TIME t)
 {
     return (time_t)(t.t / OSSL_TIME_SECOND);
 }
 
 /* Convert time_t to OSSL_TIME */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_from_time_t(time_t t)
 {
     OSSL_TIME ot;
@@ -141,7 +141,7 @@ OSSL_TIME ossl_time_from_time_t(time_t t)
 }
 
 /* Compare two time values, return -1 if less, 1 if greater and 0 if equal */
-static ossl_unused ossl_inline
+static ossl_unused inline
 int ossl_time_compare(OSSL_TIME a, OSSL_TIME b)
 {
     if (a.t > b.t)
@@ -152,20 +152,20 @@ int ossl_time_compare(OSSL_TIME a, OSSL_TIME b)
 }
 
 /* Returns true if an OSSL_TIME is ossl_time_zero(). */
-static ossl_unused ossl_inline
+static ossl_unused inline
 int ossl_time_is_zero(OSSL_TIME t)
 {
     return ossl_time_compare(t, ossl_time_zero()) == 0;
 }
 
 /* Returns true if an OSSL_TIME is ossl_time_infinite(). */
-static ossl_unused ossl_inline
+static ossl_unused inline
 int ossl_time_is_infinite(OSSL_TIME t)
 {
     return ossl_time_compare(t, ossl_time_infinite()) == 0;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_add(OSSL_TIME a, OSSL_TIME b)
 {
     OSSL_TIME r;
@@ -175,7 +175,7 @@ OSSL_TIME ossl_time_add(OSSL_TIME a, OSSL_TIME b)
     return err ? ossl_time_infinite() : r;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_subtract(OSSL_TIME a, OSSL_TIME b)
 {
     OSSL_TIME r;
@@ -186,14 +186,14 @@ OSSL_TIME ossl_time_subtract(OSSL_TIME a, OSSL_TIME b)
 }
 
 /* Returns |a - b|. */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_abs_difference(OSSL_TIME a, OSSL_TIME b)
 {
     return a.t > b.t ? ossl_time_subtract(a, b)
                      : ossl_time_subtract(b, a);
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_multiply(OSSL_TIME a, uint64_t b)
 {
     OSSL_TIME r;
@@ -203,7 +203,7 @@ OSSL_TIME ossl_time_multiply(OSSL_TIME a, uint64_t b)
     return err ? ossl_time_infinite() : r;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_divide(OSSL_TIME a, uint64_t b)
 {
     OSSL_TIME r;
@@ -213,7 +213,7 @@ OSSL_TIME ossl_time_divide(OSSL_TIME a, uint64_t b)
     return err ? ossl_time_zero() : r;
 }
 
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_muldiv(OSSL_TIME a, uint64_t b, uint64_t c)
 {
     OSSL_TIME r;
@@ -224,14 +224,14 @@ OSSL_TIME ossl_time_muldiv(OSSL_TIME a, uint64_t b, uint64_t c)
 }
 
 /* Return higher of the two given time values. */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_max(OSSL_TIME a, OSSL_TIME b)
 {
     return a.t > b.t ? a : b;
 }
 
 /* Return the lower of the two given time values. */
-static ossl_unused ossl_inline
+static ossl_unused inline
 OSSL_TIME ossl_time_min(OSSL_TIME a, OSSL_TIME b)
 {
     return a.t < b.t ? a : b;

--- a/include/internal/unicode.h
+++ b/include/internal/unicode.h
@@ -18,12 +18,12 @@ typedef enum {
     UNICODE_LIMIT
 } UNICODE_CONSTANTS;
 
-static ossl_unused ossl_inline int is_unicode_surrogate(unsigned long value)
+static ossl_unused inline int is_unicode_surrogate(unsigned long value)
 {
     return value >= SURROGATE_MIN && value <= SURROGATE_MAX;
 }
 
-static ossl_unused ossl_inline int is_unicode_valid(unsigned long value)
+static ossl_unused inline int is_unicode_valid(unsigned long value)
 {
     return value <= UNICODE_MAX && !is_unicode_surrogate(value);
 }

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -46,7 +46,7 @@ extern "C" {
  */
 #define OSSL_CORE_MAKE_FUNC(type,name,args)                             \
     typedef type (OSSL_FUNC_##name##_fn)args;                           \
-    static ossl_unused ossl_inline \
+    static ossl_unused inline \
     OSSL_FUNC_##name##_fn *OSSL_FUNC_##name(const OSSL_DISPATCH *opf)   \
     {                                                                   \
         return (OSSL_FUNC_##name##_fn *)opf->function;                  \

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -234,27 +234,6 @@ typedef int64_t ossl_intmax_t;
 typedef uint64_t ossl_uintmax_t;
 # endif
 
-/* ossl_inline: portable inline definition usable in public headers */
-# if !defined(inline) && !defined(__cplusplus)
-#  if defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
-   /* just use inline */
-#   define ossl_inline inline
-#  elif defined(__GNUC__) && __GNUC__>=2
-#   define ossl_inline __inline__
-#  elif defined(_MSC_VER)
-  /*
-   * Visual Studio: inline is available in C++ only, however
-   * __inline is available for C, see
-   * http://msdn.microsoft.com/en-us/library/z8y1yy88.aspx
-   */
-#   define ossl_inline __inline
-#  else
-#   define ossl_inline
-#  endif
-# else
-#  define ossl_inline inline
-# endif
-
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
      !defined(__cplusplus) 
 #  define ossl_noreturn _Noreturn

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -221,33 +221,33 @@ extern "C" {
 
 # define ERR_SYSTEM_ERROR(errcode)      (((errcode) & ERR_SYSTEM_FLAG) != 0)
 
-static ossl_unused ossl_inline int ERR_GET_LIB(unsigned long errcode)
+static ossl_unused inline int ERR_GET_LIB(unsigned long errcode)
 {
     if (ERR_SYSTEM_ERROR(errcode))
         return ERR_LIB_SYS;
     return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
 }
 
-static ossl_unused ossl_inline int ERR_GET_RFLAGS(unsigned long errcode)
+static ossl_unused inline int ERR_GET_RFLAGS(unsigned long errcode)
 {
     if (ERR_SYSTEM_ERROR(errcode))
         return 0;
     return errcode & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET);
 }
 
-static ossl_unused ossl_inline int ERR_GET_REASON(unsigned long errcode)
+static ossl_unused inline int ERR_GET_REASON(unsigned long errcode)
 {
     if (ERR_SYSTEM_ERROR(errcode))
         return errcode & ERR_SYSTEM_MASK;
     return errcode & ERR_REASON_MASK;
 }
 
-static ossl_unused ossl_inline int ERR_FATAL_ERROR(unsigned long errcode)
+static ossl_unused inline int ERR_FATAL_ERROR(unsigned long errcode)
 {
     return (ERR_GET_RFLAGS(errcode) & ERR_RFLAG_FATAL) != 0;
 }
 
-static ossl_unused ossl_inline int ERR_COMMON_ERROR(unsigned long errcode)
+static ossl_unused inline int ERR_COMMON_ERROR(unsigned long errcode)
 {
     return (ERR_GET_RFLAGS(errcode) & ERR_RFLAG_COMMON) != 0;
 }

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -158,57 +158,57 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
     typedef int (*lh_##type##_compfunc)(const type *a, const type *b); \
     typedef unsigned long (*lh_##type##_hashfunc)(const type *a); \
     typedef void (*lh_##type##_doallfunc)(type *a); \
-    static ossl_inline unsigned long lh_##type##_hash_thunk(const void *data, OPENSSL_LH_HASHFUNC hfn) \
+    static inline unsigned long lh_##type##_hash_thunk(const void *data, OPENSSL_LH_HASHFUNC hfn) \
     { \
         unsigned long (*hfn_conv)(const type *) = (unsigned long (*)(const type *))hfn; \
         return hfn_conv((const type *)data); \
     } \
-    static ossl_inline int lh_##type##_comp_thunk(const void *da, const void *db, OPENSSL_LH_COMPFUNC cfn) \
+    static inline int lh_##type##_comp_thunk(const void *da, const void *db, OPENSSL_LH_COMPFUNC cfn) \
     { \
         int (*cfn_conv)(const type *, const type *) = (int (*)(const type *, const type *))cfn; \
         return cfn_conv((const type *)da, (const type *)db); \
     } \
-    static ossl_inline void lh_##type##_doall_thunk(void *node, OPENSSL_LH_DOALL_FUNC doall) \
+    static inline void lh_##type##_doall_thunk(void *node, OPENSSL_LH_DOALL_FUNC doall) \
     { \
         void (*doall_conv)(type *) = (void (*)(type *))doall; \
         doall_conv((type *)node); \
     } \
-    static ossl_inline void lh_##type##_doall_arg_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG doall) \
+    static inline void lh_##type##_doall_arg_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG doall) \
     { \
         void (*doall_conv)(type *, void *) = (void (*)(type *, void *))doall; \
         doall_conv((type *)node, arg); \
     } \
-    static ossl_unused ossl_inline type *\
+    static ossl_unused inline type *\
     ossl_check_##type##_lh_plain_type(type *ptr) \
     { \
         return ptr; \
     } \
-    static ossl_unused ossl_inline const type * \
+    static ossl_unused inline const type * \
     ossl_check_const_##type##_lh_plain_type(const type *ptr) \
     { \
         return ptr; \
     } \
-    static ossl_unused ossl_inline const OPENSSL_LHASH * \
+    static ossl_unused inline const OPENSSL_LHASH * \
     ossl_check_const_##type##_lh_type(const LHASH_OF(type) *lh) \
     { \
         return (const OPENSSL_LHASH *)lh; \
     } \
-    static ossl_unused ossl_inline OPENSSL_LHASH * \
+    static ossl_unused inline OPENSSL_LHASH * \
     ossl_check_##type##_lh_type(LHASH_OF(type) *lh) \
     { \
         return (OPENSSL_LHASH *)lh; \
     } \
-    static ossl_unused ossl_inline OPENSSL_LH_COMPFUNC \
+    static ossl_unused inline OPENSSL_LH_COMPFUNC \
     ossl_check_##type##_lh_compfunc_type(lh_##type##_compfunc cmp) \
     { \
         return (OPENSSL_LH_COMPFUNC)cmp; \
     } \
-    static ossl_unused ossl_inline OPENSSL_LH_HASHFUNC \
+    static ossl_unused inline OPENSSL_LH_HASHFUNC \
     ossl_check_##type##_lh_hashfunc_type(lh_##type##_hashfunc hfn) \
     { \
         return (OPENSSL_LH_HASHFUNC)hfn; \
     } \
-    static ossl_unused ossl_inline OPENSSL_LH_DOALL_FUNC \
+    static ossl_unused inline OPENSSL_LH_DOALL_FUNC \
     ossl_check_##type##_lh_doallfunc_type(lh_##type##_doallfunc dfn) \
     { \
         return (OPENSSL_LH_DOALL_FUNC)dfn; \
@@ -217,17 +217,17 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
 
 # ifndef OPENSSL_NO_DEPRECATED_3_1
 #  define DEFINE_LHASH_OF_DEPRECATED(type) \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_node_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_node_stats_bio((const OPENSSL_LHASH *)lh, out); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_node_usage_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_node_usage_stats_bio((const OPENSSL_LHASH *)lh, out); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_stats_bio((const OPENSSL_LHASH *)lh, out); \
@@ -251,69 +251,69 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
         int (*cfn_conv)(const type *, const type *) = (int (*)(const type *, const type *))cfn; \
         return cfn_conv((const type *)da, (const type *)db); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_free(LHASH_OF(type) *lh) \
     { \
         OPENSSL_LH_free((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_flush(LHASH_OF(type) *lh) \
     { \
         OPENSSL_LH_flush((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_unused ossl_inline type * \
+    static ossl_unused inline type * \
     lh_##type##_insert(LHASH_OF(type) *lh, type *d) \
     { \
         return (type *)OPENSSL_LH_insert((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_unused ossl_inline type * \
+    static ossl_unused inline type * \
     lh_##type##_delete(LHASH_OF(type) *lh, const type *d) \
     { \
         return (type *)OPENSSL_LH_delete((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_unused ossl_inline type * \
+    static ossl_unused inline type * \
     lh_##type##_retrieve(LHASH_OF(type) *lh, const type *d) \
     { \
         return (type *)OPENSSL_LH_retrieve((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_unused ossl_inline int \
+    static ossl_unused inline int \
     lh_##type##_error(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_error((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_unused ossl_inline unsigned long \
+    static ossl_unused inline unsigned long \
     lh_##type##_num_items(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_num_items((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_unused ossl_inline unsigned long \
+    static ossl_unused inline unsigned long \
     lh_##type##_get_down_load(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_get_down_load((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_set_down_load(LHASH_OF(type) *lh, unsigned long dl) \
     { \
         OPENSSL_LH_set_down_load((OPENSSL_LHASH *)lh, dl); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_doall_thunk(void *node, OPENSSL_LH_DOALL_FUNC doall) \
     { \
         void (*doall_conv)(type *) = (void (*)(type *))doall; \
         doall_conv((type *)node); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_doall_arg_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG doall) \
     { \
         void (*doall_conv)(type *, void *) = (void (*)(type *, void *))doall; \
         doall_conv((type *)node, arg); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_doall(LHASH_OF(type) *lh, void (*doall)(type *)) \
     { \
         OPENSSL_LH_doall((OPENSSL_LHASH *)lh, (OPENSSL_LH_DOALL_FUNC)doall); \
     } \
-    static ossl_unused ossl_inline LHASH_OF(type) * \
+    static ossl_unused inline LHASH_OF(type) * \
     lh_##type##_new(unsigned long (*hfn)(const type *), \
                     int (*cfn)(const type *, const type *)) \
     { \
@@ -322,7 +322,7 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
                                 lh_##type##_doall_thunk, \
                                 lh_##type##_doall_arg_thunk); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_doall_arg(LHASH_OF(type) *lh, \
                           void (*doallarg)(type *, void *), void *arg) \
     { \
@@ -343,13 +343,13 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
     int_implement_lhash_doall(type, argtype, type)
 
 #define int_implement_lhash_doall(type, argtype, cbargtype) \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
     lh_##type##_doall_##argtype##_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG fn) \
     { \
         void (*fn_conv)(cbargtype *, argtype *) = (void (*)(cbargtype *, argtype *))fn; \
         fn_conv((cbargtype *)node, (argtype *)arg); \
     } \
-    static ossl_unused ossl_inline void \
+    static ossl_unused inline void \
         lh_##type##_doall_##argtype(LHASH_OF(type) *lh, \
                                    void (*fn)(cbargtype *, argtype *), \
                                    argtype *arg) \

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -178,38 +178,31 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
         void (*doall_conv)(type *, void *) = (void (*)(type *, void *))doall; \
         doall_conv((type *)node, arg); \
     } \
-    static ossl_unused inline type *\
-    ossl_check_##type##_lh_plain_type(type *ptr) \
+    static ossl_unused inline type *ossl_check_##type##_lh_plain_type(type *ptr) \
     { \
         return ptr; \
     } \
-    static ossl_unused inline const type * \
-    ossl_check_const_##type##_lh_plain_type(const type *ptr) \
+    static ossl_unused inline const type *ossl_check_const_##type##_lh_plain_type(const type *ptr) \
     { \
         return ptr; \
     } \
-    static ossl_unused inline const OPENSSL_LHASH * \
-    ossl_check_const_##type##_lh_type(const LHASH_OF(type) *lh) \
+    static ossl_unused inline const OPENSSL_LHASH *ossl_check_const_##type##_lh_type(const LHASH_OF(type) *lh) \
     { \
         return (const OPENSSL_LHASH *)lh; \
     } \
-    static ossl_unused inline OPENSSL_LHASH * \
-    ossl_check_##type##_lh_type(LHASH_OF(type) *lh) \
+    static ossl_unused inline OPENSSL_LHASH *ossl_check_##type##_lh_type(LHASH_OF(type) *lh) \
     { \
         return (OPENSSL_LHASH *)lh; \
     } \
-    static ossl_unused inline OPENSSL_LH_COMPFUNC \
-    ossl_check_##type##_lh_compfunc_type(lh_##type##_compfunc cmp) \
+    static ossl_unused inline OPENSSL_LH_COMPFUNC ossl_check_##type##_lh_compfunc_type(lh_##type##_compfunc cmp) \
     { \
         return (OPENSSL_LH_COMPFUNC)cmp; \
     } \
-    static ossl_unused inline OPENSSL_LH_HASHFUNC \
-    ossl_check_##type##_lh_hashfunc_type(lh_##type##_hashfunc hfn) \
+    static ossl_unused inline OPENSSL_LH_HASHFUNC ossl_check_##type##_lh_hashfunc_type(lh_##type##_hashfunc hfn) \
     { \
         return (OPENSSL_LH_HASHFUNC)hfn; \
     } \
-    static ossl_unused inline OPENSSL_LH_DOALL_FUNC \
-    ossl_check_##type##_lh_doallfunc_type(lh_##type##_doallfunc dfn) \
+    static ossl_unused inline OPENSSL_LH_DOALL_FUNC ossl_check_##type##_lh_doallfunc_type(lh_##type##_doallfunc dfn) \
     { \
         return (OPENSSL_LH_DOALL_FUNC)dfn; \
     } \

--- a/include/openssl/safestack.h.in
+++ b/include/openssl/safestack.h.in
@@ -39,27 +39,27 @@ extern "C" {
     typedef int (*sk_##t1##_compfunc)(const t3 * const *a, const t3 *const *b); \
     typedef void (*sk_##t1##_freefunc)(t3 *a); \
     typedef t3 * (*sk_##t1##_copyfunc)(const t3 *a); \
-    static ossl_unused ossl_inline t2 *ossl_check_##t1##_type(t2 *ptr) \
+    static ossl_unused inline t2 *ossl_check_##t1##_type(t2 *ptr) \
     { \
         return ptr; \
     } \
-    static ossl_unused ossl_inline const OPENSSL_STACK *ossl_check_const_##t1##_sk_type(const STACK_OF(t1) *sk) \
+    static ossl_unused inline const OPENSSL_STACK *ossl_check_const_##t1##_sk_type(const STACK_OF(t1) *sk) \
     { \
         return (const OPENSSL_STACK *)sk; \
     } \
-    static ossl_unused ossl_inline OPENSSL_STACK *ossl_check_##t1##_sk_type(STACK_OF(t1) *sk) \
+    static ossl_unused inline OPENSSL_STACK *ossl_check_##t1##_sk_type(STACK_OF(t1) *sk) \
     { \
         return (OPENSSL_STACK *)sk; \
     } \
-    static ossl_unused ossl_inline OPENSSL_sk_compfunc ossl_check_##t1##_compfunc_type(sk_##t1##_compfunc cmp) \
+    static ossl_unused inline OPENSSL_sk_compfunc ossl_check_##t1##_compfunc_type(sk_##t1##_compfunc cmp) \
     { \
         return (OPENSSL_sk_compfunc)cmp; \
     } \
-    static ossl_unused ossl_inline OPENSSL_sk_copyfunc ossl_check_##t1##_copyfunc_type(sk_##t1##_copyfunc cpy) \
+    static ossl_unused inline OPENSSL_sk_copyfunc ossl_check_##t1##_copyfunc_type(sk_##t1##_copyfunc cpy) \
     { \
         return (OPENSSL_sk_copyfunc)cpy; \
     } \
-    static ossl_unused ossl_inline OPENSSL_sk_freefunc ossl_check_##t1##_freefunc_type(sk_##t1##_freefunc fr) \
+    static ossl_unused inline OPENSSL_sk_freefunc ossl_check_##t1##_freefunc_type(sk_##t1##_freefunc fr) \
     { \
         return (OPENSSL_sk_freefunc)fr; \
     }
@@ -69,100 +69,100 @@ extern "C" {
     typedef int (*sk_##t1##_compfunc)(const t3 * const *a, const t3 *const *b); \
     typedef void (*sk_##t1##_freefunc)(t3 *a); \
     typedef t3 * (*sk_##t1##_copyfunc)(const t3 *a); \
-    static ossl_unused ossl_inline int sk_##t1##_num(const STACK_OF(t1) *sk) \
+    static ossl_unused inline int sk_##t1##_num(const STACK_OF(t1) *sk) \
     { \
         return OPENSSL_sk_num((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_value(const STACK_OF(t1) *sk, int idx) \
+    static ossl_unused inline t2 *sk_##t1##_value(const STACK_OF(t1) *sk, int idx) \
     { \
         return (t2 *)OPENSSL_sk_value((const OPENSSL_STACK *)sk, idx); \
     } \
-    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new(sk_##t1##_compfunc compare) \
+    static ossl_unused inline STACK_OF(t1) *sk_##t1##_new(sk_##t1##_compfunc compare) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new((OPENSSL_sk_compfunc)compare); \
     } \
-    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new_null(void) \
+    static ossl_unused inline STACK_OF(t1) *sk_##t1##_new_null(void) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new_null(); \
     } \
-    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new_reserve(sk_##t1##_compfunc compare, int n) \
+    static ossl_unused inline STACK_OF(t1) *sk_##t1##_new_reserve(sk_##t1##_compfunc compare, int n) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new_reserve((OPENSSL_sk_compfunc)compare, n); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_reserve(STACK_OF(t1) *sk, int n) \
+    static ossl_unused inline int sk_##t1##_reserve(STACK_OF(t1) *sk, int n) \
     { \
         return OPENSSL_sk_reserve((OPENSSL_STACK *)sk, n); \
     } \
-    static ossl_unused ossl_inline void sk_##t1##_free(STACK_OF(t1) *sk) \
+    static ossl_unused inline void sk_##t1##_free(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_free((OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline void sk_##t1##_zero(STACK_OF(t1) *sk) \
+    static ossl_unused inline void sk_##t1##_zero(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_zero((OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_delete(STACK_OF(t1) *sk, int i) \
+    static ossl_unused inline t2 *sk_##t1##_delete(STACK_OF(t1) *sk, int i) \
     { \
         return (t2 *)OPENSSL_sk_delete((OPENSSL_STACK *)sk, i); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_delete_ptr(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused inline t2 *sk_##t1##_delete_ptr(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return (t2 *)OPENSSL_sk_delete_ptr((OPENSSL_STACK *)sk, \
                                            (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_push(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused inline int sk_##t1##_push(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_push((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_unshift(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused inline int sk_##t1##_unshift(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_unshift((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_pop(STACK_OF(t1) *sk) \
+    static ossl_unused inline t2 *sk_##t1##_pop(STACK_OF(t1) *sk) \
     { \
         return (t2 *)OPENSSL_sk_pop((OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_shift(STACK_OF(t1) *sk) \
+    static ossl_unused inline t2 *sk_##t1##_shift(STACK_OF(t1) *sk) \
     { \
         return (t2 *)OPENSSL_sk_shift((OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline void sk_##t1##_pop_free(STACK_OF(t1) *sk, sk_##t1##_freefunc freefunc) \
+    static ossl_unused inline void sk_##t1##_pop_free(STACK_OF(t1) *sk, sk_##t1##_freefunc freefunc) \
     { \
         OPENSSL_sk_pop_free((OPENSSL_STACK *)sk, (OPENSSL_sk_freefunc)freefunc); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_insert(STACK_OF(t1) *sk, t2 *ptr, int idx) \
+    static ossl_unused inline int sk_##t1##_insert(STACK_OF(t1) *sk, t2 *ptr, int idx) \
     { \
         return OPENSSL_sk_insert((OPENSSL_STACK *)sk, (const void *)ptr, idx); \
     } \
-    static ossl_unused ossl_inline t2 *sk_##t1##_set(STACK_OF(t1) *sk, int idx, t2 *ptr) \
+    static ossl_unused inline t2 *sk_##t1##_set(STACK_OF(t1) *sk, int idx, t2 *ptr) \
     { \
         return (t2 *)OPENSSL_sk_set((OPENSSL_STACK *)sk, idx, (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_find(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused inline int sk_##t1##_find(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_find((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_find_ex(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused inline int sk_##t1##_find_ex(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_find_ex((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_find_all(STACK_OF(t1) *sk, t2 *ptr, int *pnum) \
+    static ossl_unused inline int sk_##t1##_find_all(STACK_OF(t1) *sk, t2 *ptr, int *pnum) \
     { \
         return OPENSSL_sk_find_all((OPENSSL_STACK *)sk, (const void *)ptr, pnum); \
     } \
-    static ossl_unused ossl_inline void sk_##t1##_sort(STACK_OF(t1) *sk) \
+    static ossl_unused inline void sk_##t1##_sort(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_sort((OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline int sk_##t1##_is_sorted(const STACK_OF(t1) *sk) \
+    static ossl_unused inline int sk_##t1##_is_sorted(const STACK_OF(t1) *sk) \
     { \
         return OPENSSL_sk_is_sorted((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline STACK_OF(t1) * sk_##t1##_dup(const STACK_OF(t1) *sk) \
+    static ossl_unused inline STACK_OF(t1) * sk_##t1##_dup(const STACK_OF(t1) *sk) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_dup((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_deep_copy(const STACK_OF(t1) *sk, \
+    static ossl_unused inline STACK_OF(t1) *sk_##t1##_deep_copy(const STACK_OF(t1) *sk, \
                                                     sk_##t1##_copyfunc copyfunc, \
                                                     sk_##t1##_freefunc freefunc) \
     { \
@@ -170,7 +170,7 @@ extern "C" {
                                             (OPENSSL_sk_copyfunc)copyfunc, \
                                             (OPENSSL_sk_freefunc)freefunc); \
     } \
-    static ossl_unused ossl_inline sk_##t1##_compfunc sk_##t1##_set_cmp_func(STACK_OF(t1) *sk, sk_##t1##_compfunc compare) \
+    static ossl_unused inline sk_##t1##_compfunc sk_##t1##_set_cmp_func(STACK_OF(t1) *sk, sk_##t1##_compfunc compare) \
     { \
         return (sk_##t1##_compfunc)OPENSSL_sk_set_cmp_func((OPENSSL_STACK *)sk, (OPENSSL_sk_compfunc)compare); \
     }

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.h
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.h
@@ -59,14 +59,14 @@ void ossl_polyval_ghash_init(u128 Htable[16], const uint64_t H[2]);
 void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag,  const uint8_t *inp, size_t len);
 
 /* Define GSWAP8/GSWAP4 - used for BOTH little and big endian architectures */
-static ossl_inline uint32_t GSWAP4(uint32_t n)
+static inline uint32_t GSWAP4(uint32_t n)
 {
     return (((n & 0x000000FF) << 24)
             | ((n & 0x0000FF00) << 8)
             | ((n & 0x00FF0000) >> 8)
             | ((n & 0xFF000000) >> 24));
 }
-static ossl_inline uint64_t GSWAP8(uint64_t n)
+static inline uint64_t GSWAP8(uint64_t n)
 {
     uint64_t result;
 

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_polyval.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_polyval.c
@@ -19,7 +19,7 @@
 #include <prov/implementations.h>
 #include "cipher_aes_gcm_siv.h"
 
-static ossl_inline void mulx_ghash(uint64_t *a)
+static inline void mulx_ghash(uint64_t *a)
 {
     uint64_t t[2], mask;
     DECLARE_IS_ENDIAN;
@@ -44,7 +44,7 @@ static ossl_inline void mulx_ghash(uint64_t *a)
 }
 
 #define aligned64(p) (((uintptr_t)p & 0x07) == 0)
-static ossl_inline void byte_reverse16(uint8_t *out, const uint8_t *in)
+static inline void byte_reverse16(uint8_t *out, const uint8_t *in)
 {
     if (aligned64(out) && aligned64(in)) {
         ((uint64_t *)out)[0] = GSWAP8(((uint64_t *)in)[1]);

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -47,37 +47,37 @@ static OSSL_FUNC_cipher_settable_ctx_params_fn cipher_ocb_settable_ctx_params;
  * The following methods could be moved into PROV_AES_OCB_HW if
  * multiple hardware implementations are ever needed.
  */
-static ossl_inline int aes_generic_ocb_setiv(PROV_AES_OCB_CTX *ctx,
+static inline int aes_generic_ocb_setiv(PROV_AES_OCB_CTX *ctx,
                                              const unsigned char *iv,
                                              size_t ivlen, size_t taglen)
 {
     return (CRYPTO_ocb128_setiv(&ctx->ocb, iv, ivlen, taglen) == 1);
 }
 
-static ossl_inline int aes_generic_ocb_setaad(PROV_AES_OCB_CTX *ctx,
+static inline int aes_generic_ocb_setaad(PROV_AES_OCB_CTX *ctx,
                                               const unsigned char *aad,
                                               size_t alen)
 {
     return CRYPTO_ocb128_aad(&ctx->ocb, aad, alen) == 1;
 }
 
-static ossl_inline int aes_generic_ocb_gettag(PROV_AES_OCB_CTX *ctx,
+static inline int aes_generic_ocb_gettag(PROV_AES_OCB_CTX *ctx,
                                               unsigned char *tag, size_t tlen)
 {
     return CRYPTO_ocb128_tag(&ctx->ocb, tag, tlen) > 0;
 }
 
-static ossl_inline int aes_generic_ocb_final(PROV_AES_OCB_CTX *ctx)
+static inline int aes_generic_ocb_final(PROV_AES_OCB_CTX *ctx)
 {
     return (CRYPTO_ocb128_finish(&ctx->ocb, ctx->tag, ctx->taglen) == 0);
 }
 
-static ossl_inline void aes_generic_ocb_cleanup(PROV_AES_OCB_CTX *ctx)
+static inline void aes_generic_ocb_cleanup(PROV_AES_OCB_CTX *ctx)
 {
     CRYPTO_ocb128_cleanup(&ctx->ocb);
 }
 
-static ossl_inline int aes_generic_ocb_cipher(PROV_AES_OCB_CTX *ctx,
+static inline int aes_generic_ocb_cipher(PROV_AES_OCB_CTX *ctx,
                                               const unsigned char *in,
                                               unsigned char *out, size_t len)
 {
@@ -91,7 +91,7 @@ static ossl_inline int aes_generic_ocb_cipher(PROV_AES_OCB_CTX *ctx,
     return 1;
 }
 
-static ossl_inline int aes_generic_ocb_copy_ctx(PROV_AES_OCB_CTX *dst,
+static inline int aes_generic_ocb_copy_ctx(PROV_AES_OCB_CTX *dst,
                                                 PROV_AES_OCB_CTX *src)
 {
     return CRYPTO_ocb128_copy_ctx(&dst->ocb, &src->ocb,

--- a/providers/implementations/digests/blake2_impl.h
+++ b/providers/implementations/digests/blake2_impl.h
@@ -17,7 +17,7 @@
 #include <string.h>
 #include "internal/endian.h"
 
-static ossl_inline uint32_t load32(const uint8_t *src)
+static inline uint32_t load32(const uint8_t *src)
 {
     DECLARE_IS_ENDIAN;
 
@@ -34,7 +34,7 @@ static ossl_inline uint32_t load32(const uint8_t *src)
     }
 }
 
-static ossl_inline uint64_t load64(const uint8_t *src)
+static inline uint64_t load64(const uint8_t *src)
 {
     DECLARE_IS_ENDIAN;
 
@@ -55,7 +55,7 @@ static ossl_inline uint64_t load64(const uint8_t *src)
     }
 }
 
-static ossl_inline void store32(uint8_t *dst, uint32_t w)
+static inline void store32(uint8_t *dst, uint32_t w)
 {
     DECLARE_IS_ENDIAN;
 
@@ -70,7 +70,7 @@ static ossl_inline void store32(uint8_t *dst, uint32_t w)
     }
 }
 
-static ossl_inline void store64(uint8_t *dst, uint64_t w)
+static inline void store64(uint8_t *dst, uint64_t w)
 {
     DECLARE_IS_ENDIAN;
 
@@ -85,7 +85,7 @@ static ossl_inline void store64(uint8_t *dst, uint64_t w)
     }
 }
 
-static ossl_inline uint64_t load48(const uint8_t *src)
+static inline uint64_t load48(const uint8_t *src)
 {
     uint64_t w = ((uint64_t)src[0])
                | ((uint64_t)src[1] <<  8)
@@ -96,7 +96,7 @@ static ossl_inline uint64_t load48(const uint8_t *src)
     return w;
 }
 
-static ossl_inline void store48(uint8_t *dst, uint64_t w)
+static inline void store48(uint8_t *dst, uint64_t w)
 {
     uint8_t *p = (uint8_t *)dst;
     p[0] = (uint8_t)w;
@@ -107,12 +107,12 @@ static ossl_inline void store48(uint8_t *dst, uint64_t w)
     p[5] = (uint8_t)(w>>40);
 }
 
-static ossl_inline uint32_t rotr32(const uint32_t w, const unsigned int c)
+static inline uint32_t rotr32(const uint32_t w, const unsigned int c)
 {
     return (w >> c) | (w << (32 - c));
 }
 
-static ossl_inline uint64_t rotr64(const uint64_t w, const unsigned int c)
+static inline uint64_t rotr64(const uint64_t w, const unsigned int c)
 {
     return (w >> c) | (w << (64 - c));
 }

--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -46,13 +46,13 @@ static const uint8_t blake2b_sigma[12][16] =
 };
 
 /* Set that it's the last block we'll compress */
-static ossl_inline void blake2b_set_lastblock(BLAKE2B_CTX *S)
+static inline void blake2b_set_lastblock(BLAKE2B_CTX *S)
 {
     S->f[0] = -1;
 }
 
 /* Initialize the hashing state. */
-static ossl_inline void blake2b_init0(BLAKE2B_CTX *S)
+static inline void blake2b_init0(BLAKE2B_CTX *S)
 {
     int i;
 

--- a/providers/implementations/digests/blake2s_prov.c
+++ b/providers/implementations/digests/blake2s_prov.c
@@ -41,13 +41,13 @@ static const uint8_t blake2s_sigma[10][16] =
 };
 
 /* Set that it's the last block we'll compress */
-static ossl_inline void blake2s_set_lastblock(BLAKE2S_CTX *S)
+static inline void blake2s_set_lastblock(BLAKE2S_CTX *S)
 {
     S->f[0] = -1;
 }
 
 /* Initialize the hashing state. */
-static ossl_inline void blake2s_init0(BLAKE2S_CTX *S)
+static inline void blake2s_init0(BLAKE2S_CTX *S)
 {
     int i;
 

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -411,7 +411,7 @@ const OSSL_PARAM *ecdh_gettable_ctx_params(ossl_unused void *vpecdhctx,
     return known_gettable_ctx_params;
 }
 
-static ossl_inline
+static inline
 size_t ecdh_size(const EC_KEY *k)
 {
     size_t degree = 0;
@@ -426,7 +426,7 @@ size_t ecdh_size(const EC_KEY *k)
     return (degree + 7) / 8;
 }
 
-static ossl_inline
+static inline
 int ecdh_plain_derive(void *vpecdhctx, unsigned char *secret,
                       size_t *psecretlen, size_t outlen)
 {
@@ -504,7 +504,7 @@ int ecdh_plain_derive(void *vpecdhctx, unsigned char *secret,
     return ret;
 }
 
-static ossl_inline
+static inline
 int ecdh_X9_63_kdf_derive(void *vpecdhctx, unsigned char *secret,
                           size_t *psecretlen, size_t outlen)
 {

--- a/providers/implementations/kdfs/argon2.c
+++ b/providers/implementations/kdfs/argon2.c
@@ -222,11 +222,11 @@ static const OSSL_PARAM *kdf_argon2_settable_ctx_params(ossl_unused void *ctx,
 static const OSSL_PARAM *kdf_argon2_gettable_ctx_params(ossl_unused void *ctx,
                                                         ossl_unused void *p_ctx);
 
-static ossl_inline uint64_t load64(const uint8_t *src);
-static ossl_inline void store32(uint8_t *dst, uint32_t w);
-static ossl_inline void store64(uint8_t *dst, uint64_t w);
-static ossl_inline uint64_t rotr64(const uint64_t w, const unsigned int c);
-static ossl_inline uint64_t mul_lower(uint64_t x, uint64_t y);
+static inline uint64_t load64(const uint8_t *src);
+static inline void store32(uint8_t *dst, uint32_t w);
+static inline void store64(uint8_t *dst, uint64_t w);
+static inline uint64_t rotr64(const uint64_t w, const unsigned int c);
+static inline uint64_t mul_lower(uint64_t x, uint64_t y);
 
 static void init_block_value(BLOCK *b, uint8_t in);
 static void copy_block(BLOCK *dst, const BLOCK *src);
@@ -254,7 +254,7 @@ static int fill_mem_blocks_mt(KDF_ARGON2 *ctx);
 # endif
 
 static int fill_mem_blocks_st(KDF_ARGON2 *ctx);
-static ossl_inline int fill_memory_blocks(KDF_ARGON2 *ctx);
+static inline int fill_memory_blocks(KDF_ARGON2 *ctx);
 
 static void initial_hash(uint8_t *blockhash, KDF_ARGON2 *ctx);
 static int initialize(KDF_ARGON2 *ctx);
@@ -266,7 +266,7 @@ static int blake2b(EVP_MD *md, EVP_MAC *mac, void *out, size_t outlen,
 static int blake2b_long(EVP_MD *md, EVP_MAC *mac, unsigned char *out,
                         size_t outlen, const void *in, size_t inlen);
 
-static ossl_inline uint64_t load64(const uint8_t *src)
+static inline uint64_t load64(const uint8_t *src)
 {
     return
       (((uint64_t)src[0]) << 0)
@@ -279,7 +279,7 @@ static ossl_inline uint64_t load64(const uint8_t *src)
     | (((uint64_t)src[7]) << 56);
 }
 
-static ossl_inline void store32(uint8_t *dst, uint32_t w)
+static inline void store32(uint8_t *dst, uint32_t w)
 {
     dst[0] = (uint8_t)(w >> 0);
     dst[1] = (uint8_t)(w >> 8);
@@ -287,7 +287,7 @@ static ossl_inline void store32(uint8_t *dst, uint32_t w)
     dst[3] = (uint8_t)(w >> 24);
 }
 
-static ossl_inline void store64(uint8_t *dst, uint64_t w)
+static inline void store64(uint8_t *dst, uint64_t w)
 {
     dst[0] = (uint8_t)(w >> 0);
     dst[1] = (uint8_t)(w >> 8);
@@ -299,12 +299,12 @@ static ossl_inline void store64(uint8_t *dst, uint64_t w)
     dst[7] = (uint8_t)(w >> 56);
 }
 
-static ossl_inline uint64_t rotr64(const uint64_t w, const unsigned int c)
+static inline uint64_t rotr64(const uint64_t w, const unsigned int c)
 {
     return (w >> c) | (w << (64 - c));
 }
 
-static ossl_inline uint64_t mul_lower(uint64_t x, uint64_t y)
+static inline uint64_t mul_lower(uint64_t x, uint64_t y)
 {
     const uint64_t m = 0xFFFFFFFFUL;
     return (x & m) * (y & m);
@@ -638,7 +638,7 @@ static int fill_mem_blocks_st(KDF_ARGON2 *ctx)
     return 1;
 }
 
-static ossl_inline int fill_memory_blocks(KDF_ARGON2 *ctx)
+static inline int fill_memory_blocks(KDF_ARGON2 *ctx)
 {
 # if !defined(ARGON2_NO_THREADS)
     return ctx->threads == 1 ? fill_mem_blocks_st(ctx) : fill_mem_blocks_mt(ctx);

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -312,7 +312,7 @@ static const OSSL_PARAM *dh_export_types(int selection)
     return dh_imexport_types(selection);
 }
 
-static ossl_inline int dh_get_params(void *key, OSSL_PARAM params[])
+static inline int dh_get_params(void *key, OSSL_PARAM params[])
 {
     DH *dh = key;
     OSSL_PARAM *p;

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -309,7 +309,7 @@ static const OSSL_PARAM *dsa_export_types(int selection)
     return dsa_imexport_types(selection);
 }
 
-static ossl_inline int dsa_get_params(void *key, OSSL_PARAM params[])
+static inline int dsa_get_params(void *key, OSSL_PARAM params[])
 {
     DSA *dsa = key;
     OSSL_PARAM *p;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -107,7 +107,7 @@ const char *sm2_query_operation_name(int operation_id)
  * This function only exports the bare keypair, domain parameters and other
  * parameters are exported separately.
  */
-static ossl_inline
+static inline
 int key_to_params(const EC_KEY *eckey, OSSL_PARAM_BLD *tmpl,
                   OSSL_PARAM params[], int include_private,
                   unsigned char **pub_key)
@@ -235,7 +235,7 @@ int key_to_params(const EC_KEY *eckey, OSSL_PARAM_BLD *tmpl,
     return ret;
 }
 
-static ossl_inline
+static inline
 int otherparams_to_params(const EC_KEY *ec, OSSL_PARAM_BLD *tmpl,
                           OSSL_PARAM params[])
 {
@@ -553,7 +553,7 @@ end:
  */
 #include "ec_kmgmt_imexport.inc"
 
-static ossl_inline
+static inline
 const OSSL_PARAM *ec_imexport_types(int selection)
 {
     int type_select = 0;

--- a/ssl/event_queue.c
+++ b/ssl/event_queue.c
@@ -75,7 +75,7 @@ void ossl_event_queue_free(OSSL_EVENT_QUEUE *queue)
     }
 }
 
-static ossl_inline
+static inline
 int event_queue_add(OSSL_EVENT_QUEUE *queue, OSSL_EVENT *event)
 {
     PRIORITY_QUEUE_OF(OSSL_EVENT) *pq =
@@ -90,7 +90,7 @@ int event_queue_add(OSSL_EVENT_QUEUE *queue, OSSL_EVENT *event)
     return 0;
 }
 
-static ossl_inline
+static inline
 void ossl_event_set(OSSL_EVENT *event, uint32_t type, uint32_t priority,
                     OSSL_TIME when, void *ctx,
                     void *payload, size_t payload_size)

--- a/ssl/priority_queue.c
+++ b/ssl/priority_queue.c
@@ -86,7 +86,7 @@ static const size_t max_nodes =
  *
  * We use an expansion factor of 8 / 5 = 1.6
  */
-static ossl_inline size_t compute_pqueue_growth(size_t target, size_t current)
+static inline size_t compute_pqueue_growth(size_t target, size_t current)
 {
     int err = 0;
 
@@ -103,7 +103,7 @@ static ossl_inline size_t compute_pqueue_growth(size_t target, size_t current)
     return current;
 }
 
-static ossl_inline void pqueue_swap_elem(OSSL_PQUEUE *pq, size_t i, size_t j)
+static inline void pqueue_swap_elem(OSSL_PQUEUE *pq, size_t i, size_t j)
 {
     struct pq_heap_st *h = pq->heap, t_h;
     struct pq_elem_st *e = pq->elements;
@@ -119,7 +119,7 @@ static ossl_inline void pqueue_swap_elem(OSSL_PQUEUE *pq, size_t i, size_t j)
     e[h[j].index].posn = j;
 }
 
-static ossl_inline void pqueue_move_elem(OSSL_PQUEUE *pq, size_t from, size_t to)
+static inline void pqueue_move_elem(OSSL_PQUEUE *pq, size_t from, size_t to)
 {
     struct pq_heap_st *h = pq->heap;
     struct pq_elem_st *e = pq->elements;
@@ -134,7 +134,7 @@ static ossl_inline void pqueue_move_elem(OSSL_PQUEUE *pq, size_t from, size_t to
  * Force the specified element to the front of the heap.  This breaks
  * the heap partial ordering pre-condition.
  */
-static ossl_inline void pqueue_force_bottom(OSSL_PQUEUE *pq, size_t n)
+static inline void pqueue_force_bottom(OSSL_PQUEUE *pq, size_t n)
 {
     ASSERT_USED(pq, n);
     while (n > 0) {
@@ -150,7 +150,7 @@ static ossl_inline void pqueue_force_bottom(OSSL_PQUEUE *pq, size_t n)
  * Move an element down to its correct position to restore the partial
  * order pre-condition.
  */
-static ossl_inline void pqueue_move_down(OSSL_PQUEUE *pq, size_t n)
+static inline void pqueue_move_down(OSSL_PQUEUE *pq, size_t n)
 {
     struct pq_heap_st *h = pq->heap;
 
@@ -170,7 +170,7 @@ static ossl_inline void pqueue_move_down(OSSL_PQUEUE *pq, size_t n)
  * Move an element up to its correct position to restore the partial
  * order pre-condition.
  */
-static ossl_inline void pqueue_move_up(OSSL_PQUEUE *pq, size_t n)
+static inline void pqueue_move_up(OSSL_PQUEUE *pq, size_t n)
 {
     struct pq_heap_st *h = pq->heap;
     size_t p = n * 2 + 1;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2438,7 +2438,7 @@ const SSL_METHOD *func_name(void)  \
 
 const char *ssl_protocol_to_string(int version);
 
-static ossl_inline int tls12_rpk_and_privkey(const SSL_CONNECTION *sc, int idx)
+static inline int tls12_rpk_and_privkey(const SSL_CONNECTION *sc, int idx)
 {
     /*
      * This is to check for special cases when using RPK with just
@@ -2450,7 +2450,7 @@ static ossl_inline int tls12_rpk_and_privkey(const SSL_CONNECTION *sc, int idx)
         && sc->cert->pkeys[idx].x509 == NULL;
 }
 
-static ossl_inline int ssl_has_cert_type(const SSL_CONNECTION *sc, unsigned char ct)
+static inline int ssl_has_cert_type(const SSL_CONNECTION *sc, unsigned char ct)
 {
     unsigned char *ptr;
     size_t len;
@@ -2470,7 +2470,7 @@ static ossl_inline int ssl_has_cert_type(const SSL_CONNECTION *sc, unsigned char
 }
 
 /* Returns true if certificate and private key for 'idx' are present */
-static ossl_inline int ssl_has_cert(const SSL_CONNECTION *s, int idx)
+static inline int ssl_has_cert(const SSL_CONNECTION *s, int idx)
 {
     if (idx < 0 || idx >= (int)s->ssl_pkey_num)
         return 0;
@@ -2483,7 +2483,7 @@ static ossl_inline int ssl_has_cert(const SSL_CONNECTION *s, int idx)
         && s->cert->pkeys[idx].privatekey != NULL;
 }
 
-static ossl_inline void tls1_get_peer_groups(SSL_CONNECTION *s,
+static inline void tls1_get_peer_groups(SSL_CONNECTION *s,
                                              const uint16_t **pgroups,
                                              size_t *pgroupslen)
 {
@@ -3000,7 +3000,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss);
 # endif
 
 /* Some helper routines to support TSAN operations safely */
-static ossl_unused ossl_inline int ssl_tsan_lock(const SSL_CTX *ctx)
+static ossl_unused inline int ssl_tsan_lock(const SSL_CTX *ctx)
 {
 #ifdef TSAN_REQUIRES_LOCKING
     if (!CRYPTO_THREAD_write_lock(ctx->tsan_lock))
@@ -3009,14 +3009,14 @@ static ossl_unused ossl_inline int ssl_tsan_lock(const SSL_CTX *ctx)
     return 1;
 }
 
-static ossl_unused ossl_inline void ssl_tsan_unlock(const SSL_CTX *ctx)
+static ossl_unused inline void ssl_tsan_unlock(const SSL_CTX *ctx)
 {
 #ifdef TSAN_REQUIRES_LOCKING
     CRYPTO_THREAD_unlock(ctx->tsan_lock);
 #endif
 }
 
-static ossl_unused ossl_inline void ssl_tsan_counter(const SSL_CTX *ctx,
+static ossl_unused inline void ssl_tsan_counter(const SSL_CTX *ctx,
                                                      TSAN_QUALIFIER int *stat)
 {
     if (ssl_tsan_lock(ctx)) {

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -22,7 +22,7 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck);
 
 DEFINE_STACK_OF(SSL_SESSION)
 
-__owur static ossl_inline int sess_timedout(OSSL_TIME t, SSL_SESSION *ss)
+__owur static inline int sess_timedout(OSSL_TIME t, SSL_SESSION *ss)
 {
     return ossl_time_compare(t, ss->calc_timeout) > 0;
 }
@@ -31,7 +31,7 @@ __owur static ossl_inline int sess_timedout(OSSL_TIME t, SSL_SESSION *ss)
  * Returns -1/0/+1 as other XXXcmp-type functions
  * Takes calculated timeout into consideration
  */
-__owur static ossl_inline int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
+__owur static inline int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
 {
     return ossl_time_compare(a->calc_timeout, b->calc_timeout);
 }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -986,7 +986,7 @@ static int final_renegotiate(SSL_CONNECTION *s, unsigned int context, int sent)
     return 1;
 }
 
-static ossl_inline void ssl_tsan_decr(const SSL_CTX *ctx,
+static inline void ssl_tsan_decr(const SSL_CTX *ctx,
                                       TSAN_QUALIFIER int *stat)
 {
     if (ssl_tsan_lock(ctx)) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -33,12 +33,12 @@ static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL_CONNECTION *s,
 static MSG_PROCESS_RETURN tls_process_encrypted_extensions(SSL_CONNECTION *s,
                                                            PACKET *pkt);
 
-static ossl_inline int cert_req_allowed(SSL_CONNECTION *s);
+static inline int cert_req_allowed(SSL_CONNECTION *s);
 static int key_exchange_expected(SSL_CONNECTION *s);
 static int ssl_cipher_list_to_bytes(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *sk,
                                     WPACKET *pkt);
 
-static ossl_inline int received_server_cert(SSL_CONNECTION *sc)
+static inline int received_server_cert(SSL_CONNECTION *sc)
 {
     return sc->session->peer_rpk != NULL || sc->session->peer != NULL;
 }
@@ -50,7 +50,7 @@ static ossl_inline int received_server_cert(SSL_CONNECTION *sc)
  *  1: Yes
  *  0: No
  */
-static ossl_inline int cert_req_allowed(SSL_CONNECTION *s)
+static inline int cert_req_allowed(SSL_CONNECTION *s)
 {
     /* TLS does not like anon-DH with client cert */
     if ((s->version > SSL3_VERSION

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -47,7 +47,7 @@ IMPLEMENT_ASN1_FUNCTIONS(GOST_KX_MESSAGE)
 static CON_FUNC_RETURN tls_construct_encrypted_extensions(SSL_CONNECTION *s,
                                                           WPACKET *pkt);
 
-static ossl_inline int received_client_cert(const SSL_CONNECTION *sc)
+static inline int received_client_cert(const SSL_CONNECTION *sc)
 {
     return sc->session->peer_rpk != NULL || sc->session->peer != NULL;
 }
@@ -845,7 +845,7 @@ WORK_STATE ossl_statem_server_pre_work(SSL_CONNECTION *s, WORK_STATE wst)
     return WORK_FINISHED_CONTINUE;
 }
 
-static ossl_inline int conn_is_closed(void)
+static inline int conn_is_closed(void)
 {
     switch (get_last_sys_error()) {
 #if defined(EPIPE)

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -1208,7 +1208,7 @@ static int check_named_curve_lookup_test(int id)
  * This function returns TRUE (1) if the checked nids are identical, or if they
  * alias to the same curve. FALSE (0) otherwise.
  */
-static ossl_inline
+static inline
 int are_ec_nids_compatible(int n1d, int n2d)
 {
     int ret = 0;
@@ -1825,7 +1825,7 @@ err:
  *
  * If P is NULL use point at infinity.
  */
-static ossl_inline
+static inline
 int ec_point_hex2point_test_helper(const EC_GROUP *group, const EC_POINT *P,
                                    point_conversion_form_t form,
                                    BN_CTX *bnctx)

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -76,14 +76,14 @@ void test_close_streams(void)
 #endif
 }
 
-static ossl_inline void test_io_lock(void)
+static inline void test_io_lock(void)
 {
 #if defined(OPENSSL_THREADS)
     OPENSSL_assert(CRYPTO_THREAD_write_lock(io_lock) > 0);
 #endif
 }
 
-static ossl_inline void test_io_unlock(void)
+static inline void test_io_unlock(void)
 {
 #if defined(OPENSSL_THREADS)
     CRYPTO_THREAD_unlock(io_lock);

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -786,7 +786,7 @@ static void *xor_dup(const void *vfromkey, int selection)
     return tokey;
 }
 
-static ossl_inline int xor_get_params(void *vkey, OSSL_PARAM params[])
+static inline int xor_get_params(void *vkey, OSSL_PARAM params[])
 {
     XORKEY *key = vkey;
     OSSL_PARAM *p;

--- a/util/mknum.pl
+++ b/util/mknum.pl
@@ -77,7 +77,7 @@ foreach my $f (($symhacks_file // (), @ARGV)) {
                 && $_->{value} =~ /^\w(?:\w|\d)*/) {
             $ordinals->add_alias($f, $_->{value}, $_->{name}, @{$_->{conds}});
         } else {
-            next if $_->{returntype} =~ /\b(?:ossl_)inline/;
+            next if $_->{returntype} =~ /\b(?:ossl_)?inline/;
             my $type = {
                 F => 'FUNCTION',
                 V => 'VARIABLE',

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -279,7 +279,7 @@ my @opensslchandlers = (
       massager => sub {
           return (<<"EOF");
 typedef $1 OSSL_FUNC_$2_fn$3;
-static ossl_inline OSSL_FUNC_$2_fn *OSSL_FUNC_$2(const OSSL_DISPATCH *opf);
+static inline OSSL_FUNC_$2_fn *OSSL_FUNC_$2(const OSSL_DISPATCH *opf);
 EOF
       },
     },
@@ -295,21 +295,21 @@ EOF
     { regexp   => qr/DEFINE_LHASH_OF(?:_INTERNAL|_EX)?<<<\((.*)\)>>>/,
       massager => sub {
           return (<<"EOF");
-static ossl_inline LHASH_OF($1) * lh_$1_new(unsigned long (*hfn)(const $1 *),
+static inline LHASH_OF($1) * lh_$1_new(unsigned long (*hfn)(const $1 *),
                                             int (*cfn)(const $1 *, const $1 *));
-static ossl_inline void lh_$1_free(LHASH_OF($1) *lh);
-static ossl_inline $1 *lh_$1_insert(LHASH_OF($1) *lh, $1 *d);
-static ossl_inline $1 *lh_$1_delete(LHASH_OF($1) *lh, const $1 *d);
-static ossl_inline $1 *lh_$1_retrieve(LHASH_OF($1) *lh, const $1 *d);
-static ossl_inline int lh_$1_error(LHASH_OF($1) *lh);
-static ossl_inline unsigned long lh_$1_num_items(LHASH_OF($1) *lh);
-static ossl_inline void lh_$1_node_stats_bio(const LHASH_OF($1) *lh, BIO *out);
-static ossl_inline void lh_$1_node_usage_stats_bio(const LHASH_OF($1) *lh,
+static inline void lh_$1_free(LHASH_OF($1) *lh);
+static inline $1 *lh_$1_insert(LHASH_OF($1) *lh, $1 *d);
+static inline $1 *lh_$1_delete(LHASH_OF($1) *lh, const $1 *d);
+static inline $1 *lh_$1_retrieve(LHASH_OF($1) *lh, const $1 *d);
+static inline int lh_$1_error(LHASH_OF($1) *lh);
+static inline unsigned long lh_$1_num_items(LHASH_OF($1) *lh);
+static inline void lh_$1_node_stats_bio(const LHASH_OF($1) *lh, BIO *out);
+static inline void lh_$1_node_usage_stats_bio(const LHASH_OF($1) *lh,
                                                    BIO *out);
-static ossl_inline void lh_$1_stats_bio(const LHASH_OF($1) *lh, BIO *out);
-static ossl_inline unsigned long lh_$1_get_down_load(LHASH_OF($1) *lh);
-static ossl_inline void lh_$1_set_down_load(LHASH_OF($1) *lh, unsigned long dl);
-static ossl_inline void lh_$1_doall(LHASH_OF($1) *lh, void (*doall)($1 *));
+static inline void lh_$1_stats_bio(const LHASH_OF($1) *lh, BIO *out);
+static inline unsigned long lh_$1_get_down_load(LHASH_OF($1) *lh);
+static inline void lh_$1_set_down_load(LHASH_OF($1) *lh, unsigned long dl);
+static inline void lh_$1_doall(LHASH_OF($1) *lh, void (*doall)($1 *));
 LHASH_OF($1)
 EOF
       }
@@ -339,34 +339,34 @@ STACK_OF($1);
 typedef int (*sk_$1_compfunc)(const $3 * const *a, const $3 *const *b);
 typedef void (*sk_$1_freefunc)($3 *a);
 typedef $3 * (*sk_$1_copyfunc)(const $3 *a);
-static ossl_inline int sk_$1_num(const STACK_OF($1) *sk);
-static ossl_inline $2 *sk_$1_value(const STACK_OF($1) *sk, int idx);
-static ossl_inline STACK_OF($1) *sk_$1_new(sk_$1_compfunc compare);
-static ossl_inline STACK_OF($1) *sk_$1_new_null(void);
-static ossl_inline STACK_OF($1) *sk_$1_new_reserve(sk_$1_compfunc compare,
+static inline int sk_$1_num(const STACK_OF($1) *sk);
+static inline $2 *sk_$1_value(const STACK_OF($1) *sk, int idx);
+static inline STACK_OF($1) *sk_$1_new(sk_$1_compfunc compare);
+static inline STACK_OF($1) *sk_$1_new_null(void);
+static inline STACK_OF($1) *sk_$1_new_reserve(sk_$1_compfunc compare,
                                                    int n);
-static ossl_inline int sk_$1_reserve(STACK_OF($1) *sk, int n);
-static ossl_inline void sk_$1_free(STACK_OF($1) *sk);
-static ossl_inline void sk_$1_zero(STACK_OF($1) *sk);
-static ossl_inline $2 *sk_$1_delete(STACK_OF($1) *sk, int i);
-static ossl_inline $2 *sk_$1_delete_ptr(STACK_OF($1) *sk, $2 *ptr);
-static ossl_inline int sk_$1_push(STACK_OF($1) *sk, $2 *ptr);
-static ossl_inline int sk_$1_unshift(STACK_OF($1) *sk, $2 *ptr);
-static ossl_inline $2 *sk_$1_pop(STACK_OF($1) *sk);
-static ossl_inline $2 *sk_$1_shift(STACK_OF($1) *sk);
-static ossl_inline void sk_$1_pop_free(STACK_OF($1) *sk,
+static inline int sk_$1_reserve(STACK_OF($1) *sk, int n);
+static inline void sk_$1_free(STACK_OF($1) *sk);
+static inline void sk_$1_zero(STACK_OF($1) *sk);
+static inline $2 *sk_$1_delete(STACK_OF($1) *sk, int i);
+static inline $2 *sk_$1_delete_ptr(STACK_OF($1) *sk, $2 *ptr);
+static inline int sk_$1_push(STACK_OF($1) *sk, $2 *ptr);
+static inline int sk_$1_unshift(STACK_OF($1) *sk, $2 *ptr);
+static inline $2 *sk_$1_pop(STACK_OF($1) *sk);
+static inline $2 *sk_$1_shift(STACK_OF($1) *sk);
+static inline void sk_$1_pop_free(STACK_OF($1) *sk,
                                        sk_$1_freefunc freefunc);
-static ossl_inline int sk_$1_insert(STACK_OF($1) *sk, $2 *ptr, int idx);
-static ossl_inline $2 *sk_$1_set(STACK_OF($1) *sk, int idx, $2 *ptr);
-static ossl_inline int sk_$1_find(STACK_OF($1) *sk, $2 *ptr);
-static ossl_inline int sk_$1_find_ex(STACK_OF($1) *sk, $2 *ptr);
-static ossl_inline void sk_$1_sort(STACK_OF($1) *sk);
-static ossl_inline int sk_$1_is_sorted(const STACK_OF($1) *sk);
-static ossl_inline STACK_OF($1) * sk_$1_dup(const STACK_OF($1) *sk);
-static ossl_inline STACK_OF($1) *sk_$1_deep_copy(const STACK_OF($1) *sk,
+static inline int sk_$1_insert(STACK_OF($1) *sk, $2 *ptr, int idx);
+static inline $2 *sk_$1_set(STACK_OF($1) *sk, int idx, $2 *ptr);
+static inline int sk_$1_find(STACK_OF($1) *sk, $2 *ptr);
+static inline int sk_$1_find_ex(STACK_OF($1) *sk, $2 *ptr);
+static inline void sk_$1_sort(STACK_OF($1) *sk);
+static inline int sk_$1_is_sorted(const STACK_OF($1) *sk);
+static inline STACK_OF($1) * sk_$1_dup(const STACK_OF($1) *sk);
+static inline STACK_OF($1) *sk_$1_deep_copy(const STACK_OF($1) *sk,
                                                  sk_$1_copyfunc copyfunc,
                                                  sk_$1_freefunc freefunc);
-static ossl_inline sk_$1_compfunc sk_$1_set_cmp_func(STACK_OF($1) *sk,
+static inline sk_$1_compfunc sk_$1_set_cmp_func(STACK_OF($1) *sk,
                                                      sk_$1_compfunc compare);
 EOF
       }
@@ -378,11 +378,11 @@ STACK_OF($1);
 typedef int (*sk_$1_compfunc)(const $3 * const *a, const $3 *const *b);
 typedef void (*sk_$1_freefunc)($3 *a);
 typedef $3 * (*sk_$1_copyfunc)(const $3 *a);
-static ossl_unused ossl_inline $2 *ossl_check_$1_type($2 *ptr);
-static ossl_unused ossl_inline const OPENSSL_STACK *ossl_check_const_$1_sk_type(const STACK_OF($1) *sk);
-static ossl_unused ossl_inline OPENSSL_sk_compfunc ossl_check_$1_compfunc_type(sk_$1_compfunc cmp);
-static ossl_unused ossl_inline OPENSSL_sk_copyfunc ossl_check_$1_copyfunc_type(sk_$1_copyfunc cpy);
-static ossl_unused ossl_inline OPENSSL_sk_freefunc ossl_check_$1_freefunc_type(sk_$1_freefunc fr);
+static ossl_unused inline $2 *ossl_check_$1_type($2 *ptr);
+static ossl_unused inline const OPENSSL_STACK *ossl_check_const_$1_sk_type(const STACK_OF($1) *sk);
+static ossl_unused inline OPENSSL_sk_compfunc ossl_check_$1_compfunc_type(sk_$1_compfunc cmp);
+static ossl_unused inline OPENSSL_sk_copyfunc ossl_check_$1_copyfunc_type(sk_$1_copyfunc cpy);
+static ossl_unused inline OPENSSL_sk_freefunc ossl_check_$1_freefunc_type(sk_$1_freefunc fr);
 EOF
       }
     },


### PR DESCRIPTION
I checked with a recent MSFT Visual C also.
Starting to use C99.
## Checklist
Thank you for your contribution. Please answer the following:

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
