### PR TITLE
no-sock implies no-http

### DIFF
--- a/Configure
+++ b/Configure
@@ -608,7 +608,7 @@ my @disable_cascades = (
     "zstd"              => [ "zstd-dynamic" ],
     "des"               => [ "mdc2" ],
     "ec"                => [ "ecdsa", "sm2", "gost", "ecx", "boring-quic-api" ],
-    "sock"              => [ "dtls", "sctp", "tfo" ],
+    "sock"              => [ "dtls", "sctp", "http", "ocsp", "tfo" ],
     "dtls"              => [ @dtls ],
     sub { 0 == scalar grep { !$disabled{$_} } @dtls }
                         => [ "dtls" ],

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -68,7 +68,7 @@ typedef enum {
 } cmp_cmd_t;
 
 /* message transfer */
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 static char *opt_server = NULL;
 static char *opt_proxy = NULL;
 static char *opt_no_proxy = NULL;
@@ -148,7 +148,7 @@ static int opt_keyform = FORMAT_UNDEF;
 static char *opt_otherpass = NULL;
 static char *opt_engine = NULL;
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 /* TLS connection */
 static int opt_tls_used = 0;
 static char *opt_tls_cert = NULL;
@@ -173,7 +173,7 @@ static char *opt_rspout = NULL;
 static int opt_use_mock_srv = 0;
 
 /* mock server */
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 static char *opt_port = NULL;
 static int opt_max_msgs = 0;
 #endif
@@ -226,7 +226,7 @@ typedef enum OPTION_choice {
 
     OPT_OLDCERT, OPT_ISSUER, OPT_SERIAL, OPT_REVREASON,
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     OPT_SERVER, OPT_PROXY, OPT_NO_PROXY,
 #endif
     OPT_RECIPIENT, OPT_PATH,
@@ -250,7 +250,7 @@ typedef enum OPTION_choice {
     OPT_PROV_ENUM,
     OPT_R_ENUM,
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     OPT_TLS_USED, OPT_TLS_CERT, OPT_TLS_KEY,
     OPT_TLS_KEYPASS,
     OPT_TLS_EXTRA, OPT_TLS_TRUSTED, OPT_TLS_HOST,
@@ -261,7 +261,7 @@ typedef enum OPTION_choice {
     OPT_RSPIN, OPT_RSPOUT,
     OPT_USE_MOCK_SRV,
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     OPT_PORT, OPT_MAX_MSGS,
 #endif
     OPT_SRV_REF, OPT_SRV_SECRET,
@@ -368,7 +368,7 @@ const OPTIONS cmp_options[] = {
      "0..6, 8..10 (see RFC5280, 5.3.1) or -1. Default -1 = none included"},
 
     OPT_SECTION("Message transfer"),
-#if defined(OPENSSL_NO_SOCK) || defined(OPENSSL_NO_HTTP)
+#if defined(OPENSSL_NO_HTTP)
     {OPT_MORE_STR, 0, 0,
      "NOTE: -server, -proxy, and -no_proxy not supported due to no-sock/no-http build"},
 #else
@@ -473,7 +473,7 @@ const OPTIONS cmp_options[] = {
     OPT_R_OPTIONS,
 
     OPT_SECTION("TLS connection"),
-#if defined(OPENSSL_NO_SOCK) || defined(OPENSSL_NO_HTTP)
+#if defined(OPENSSL_NO_HTTP)
     {OPT_MORE_STR, 0, 0,
      "NOTE: -tls_used and all other TLS options not supported due to no-sock/no-http build"},
 #else
@@ -516,7 +516,7 @@ const OPTIONS cmp_options[] = {
      "Use internal mock server at API level, bypassing socket-based HTTP"},
 
     OPT_SECTION("Mock server"),
-#if defined(OPENSSL_NO_SOCK) || defined(OPENSSL_NO_HTTP)
+#if defined(OPENSSL_NO_HTTP)
     {OPT_MORE_STR, 0, 0,
      "NOTE: -port and -max_msgs not supported due to no-sock/no-http build"},
 #else
@@ -611,7 +611,7 @@ static varref cmp_vars[] = { /* must be in same order as enumerated above! */
 
     {&opt_oldcert}, {&opt_issuer}, {&opt_serial}, {(char **)&opt_revreason},
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     {&opt_server}, {&opt_proxy}, {&opt_no_proxy},
 #endif
     {&opt_recipient}, {&opt_path}, {(char **)&opt_keep_alive},
@@ -635,7 +635,7 @@ static varref cmp_vars[] = { /* must be in same order as enumerated above! */
     {&opt_engine},
 #endif
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     {(char **)&opt_tls_used}, {&opt_tls_cert}, {&opt_tls_key},
     {&opt_tls_keypass},
     {&opt_tls_extra}, {&opt_tls_trusted}, {&opt_tls_host},
@@ -646,7 +646,7 @@ static varref cmp_vars[] = { /* must be in same order as enumerated above! */
     {&opt_reqout}, {&opt_reqout_only}, {&opt_rspin}, {&opt_rspout},
 
     {(char **)&opt_use_mock_srv},
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     {&opt_port}, {(char **)&opt_max_msgs},
 #endif
     {&opt_srv_ref}, {&opt_srv_secret},
@@ -859,7 +859,7 @@ static OSSL_CMP_MSG *read_write_req_resp(OSSL_CMP_CTX *ctx,
                 CMP_warn("too few -rspin filename arguments; resorting to using mock server");
             res = OSSL_CMP_CTX_server_perform(ctx, actual_req);
         } else {
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
             if (opt_server == NULL) {
                 CMP_err("missing -server or -use_mock_srv option, or too few -rspin filename arguments");
                 goto err;
@@ -1282,7 +1282,7 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
     return 1;
 }
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 /*
  * set up ssl_ctx for the OSSL_CMP_CTX based on options from config file/CLI.
  * Returns pointer on success, NULL on error
@@ -2038,7 +2038,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {
     int ret = 0;
     char *host = NULL, *port = NULL, *path = NULL, *used_path = opt_path;
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     int portnum, use_ssl;
     static char server_port[32] = { '\0' };
     const char *proxy_host = NULL;
@@ -2049,7 +2049,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
     if (!opt_use_mock_srv)
         strcpy(server_buf, "no server");
     if (!opt_use_mock_srv && opt_rspin == NULL) { /* note: -port is not given */
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         if (opt_server == NULL && opt_reqout_only == NULL) {
             CMP_err("missing -server or -use_mock_srv or -rspin option");
             goto err;
@@ -2059,7 +2059,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         goto err;
 #endif
     }
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     if (opt_server == NULL) {
         if (opt_proxy != NULL)
             CMP_warn("ignoring -proxy option since -server is not given");
@@ -2163,7 +2163,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             || opt_rspin != NULL || opt_rspout != NULL || opt_use_mock_srv)
         (void)OSSL_CMP_CTX_set_transfer_cb(ctx, read_write_req_resp);
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     if (opt_tls_used) {
         APP_HTTP_TLS_INFO *info;
 
@@ -2600,7 +2600,7 @@ static int get_opts(int argc, char **argv)
             if (!set_verbosity(opt_int_arg()))
                 goto opthelp;
             break;
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         case OPT_SERVER:
             opt_server = opt_str();
             break;
@@ -2630,7 +2630,7 @@ static int get_opts(int argc, char **argv)
         case OPT_TOTAL_TIMEOUT:
             opt_total_timeout = opt_int_arg();
             break;
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         case OPT_TLS_USED:
             opt_tls_used = 1;
             break;
@@ -2870,7 +2870,7 @@ static int get_opts(int argc, char **argv)
             opt_use_mock_srv = 1;
             break;
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         case OPT_PORT:
             opt_port = opt_str();
             break;
@@ -2968,7 +2968,7 @@ static int get_opts(int argc, char **argv)
     return 1;
 }
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
 {
     BIO *acbio;
@@ -3056,7 +3056,7 @@ static void print_status(void)
         OSSL_CMP_CTX_snprint_PKIStatus(cmp_ctx, buf, OSSL_CMP_PKISI_BUFLEN);
     const char *from = "", *server = "";
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     if (opt_server != NULL) {
         from = " from ";
         server = opt_server;
@@ -3285,7 +3285,7 @@ int cmp_main(int argc, char **argv)
         goto err;
     }
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     if (opt_tls_cert == NULL && opt_tls_key == NULL && opt_tls_keypass == NULL
             && opt_tls_extra == NULL && opt_tls_trusted == NULL
             && opt_tls_host == NULL) {
@@ -3325,7 +3325,7 @@ int cmp_main(int argc, char **argv)
                                       1);
 
     if (opt_reqout_only == NULL && (opt_use_mock_srv
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
                                     || opt_port != NULL
 #endif
                                     )) {
@@ -3342,7 +3342,7 @@ int cmp_main(int argc, char **argv)
         OSSL_CMP_CTX_set_log_verbosity(srv_cmp_ctx, opt_verbosity);
     }
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     if (opt_tls_used && (opt_use_mock_srv || opt_server == NULL)) {
         CMP_warn("ignoring -tls_used option since -use_mock_srv is given or -server is not given");
         opt_tls_used = 0;
@@ -3358,7 +3358,7 @@ int cmp_main(int argc, char **argv)
     if (opt_reqout_only != NULL) {
         const char *msg = "option is ignored since -reqout_only option is given";
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         if (opt_server != NULL)
             CMP_warn1("-server %s", msg);
 #endif
@@ -3452,7 +3452,7 @@ int cmp_main(int argc, char **argv)
     cleanse(opt_keypass);
     cleanse(opt_newkeypass);
     cleanse(opt_otherpass);
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
     cleanse(opt_tls_keypass);
 #endif
     cleanse(opt_secret);
@@ -3463,7 +3463,7 @@ int cmp_main(int argc, char **argv)
         OSSL_CMP_CTX_print_errors(cmp_ctx);
 
     if (cmp_ctx != NULL) {
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         APP_HTTP_TLS_INFO *info = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
 
         (void)OSSL_CMP_CTX_set_http_cb_arg(cmp_ctx, NULL);
@@ -3472,7 +3472,7 @@ int cmp_main(int argc, char **argv)
         X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
         /* cannot free info already here, as it may be used indirectly by: */
         OSSL_CMP_CTX_free(cmp_ctx);
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
         if (info != NULL) {
             OPENSSL_free((char *)info->server);
             OPENSSL_free((char *)info->port);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2468,7 +2468,7 @@ void store_setup_crl_download(X509_STORE *st)
     X509_STORE_set_lookup_crls_cb(st, crls_http_cb);
 }
 
-#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+#if !defined(OPENSSL_NO_HTTP)
 static const char *tls_error_hint(void)
 {
     unsigned long err = ERR_peek_error();


### PR DESCRIPTION
So we can simplify the (only done sometimes... why?) tests for OPENSSL_NO_SOCK with OPENSSL_NO_HTTP and only test for the latter.

## Checklist
Thank you for your contribution. Please answer the following:

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
