### PR TITLE
Fix daily CI run

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
-          386,
           no-afalgeng,
           no-apps,
           no-aria,
@@ -51,7 +50,6 @@ jobs:
           no-dtls1_2,
           no-dtls1_2-method,
           no-dtls1-method,
-          no-ecdsa,
           enable-ec_nistp_64_gcc_128,
           no-ec_nistp_64_gcc_128,
           no-engine,


### PR DESCRIPTION
PR #116 removed ecdsa as a separate config option. The "386" config option is a no-op

## Checklist
Thank you for your contribution. Please answer the following:

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
