### PR TITLE
Clean up code,doc for X509_NAME_print

### DIFF
--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -561,7 +561,7 @@ int X509_NAME_print_ex(BIO *out, const X509_NAME *nm, int indent,
                        unsigned long flags)
 {
     if (flags == XN_FLAG_COMPAT)
-        return X509_NAME_print(out, nm, indent);
+        return X509_NAME_print(out, nm, 0);
     return do_name_ex(send_bio_chars, out, nm, indent, flags);
 }
 
@@ -572,10 +572,11 @@ int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm, int indent,
     if (flags == XN_FLAG_COMPAT) {
         BIO *btmp;
         int ret;
+
         btmp = BIO_new_fp(fp, BIO_NOCLOSE);
-        if (!btmp)
+        if (btmp == NULL)
             return -1;
-        ret = X509_NAME_print(btmp, nm, indent);
+        ret = X509_NAME_print(btmp, nm, 0);
         BIO_free(btmp);
         return ret;
     }

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -500,7 +500,7 @@ int X509_NAME_set(X509_NAME **xn, const X509_NAME *name)
     return 1;
 }
 
-int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
+int X509_NAME_print(BIO *bp, const X509_NAME *name, int dummy)
 {
     char *s, *c, *b;
     int i;
@@ -514,13 +514,14 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
     }
     s = b + 1;                  /* skip the first slash */
 
-    c = s;
-    for (;;) {
-        if (((*s == '/') &&
-             (ossl_isupper(s[1]) && ((s[2] == '=') ||
-                                (ossl_isupper(s[2]) && (s[3] == '='))
-              ))) || (*s == '\0'))
-        {
+    for (c = s; ; s++) {
+        int ended = *s == '\0';
+        if (!ended)
+            ended = *s == '/'
+                && (ossl_isupper(s[1])
+                        && (s[2] == '='
+                            || (ossl_isupper(s[2]) && s[3] == '=')));
+        if (ended) {
             i = s - c;
             if (BIO_write(bp, c, i) != i)
                 goto err;
@@ -532,7 +533,6 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
         }
         if (*s == '\0')
             break;
-        s++;
     }
 
     OPENSSL_free(b);

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -14,7 +14,7 @@ X509_NAME_oneline - X509_NAME printing routines
  int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm,
                            int indent, unsigned long flags);
  char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
- int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase);
+ int X509_NAME_print(BIO *bp, const X509_NAME *name, int dummy);
 
 =head1 DESCRIPTION
 
@@ -32,9 +32,9 @@ I<size> is ignored.
 Otherwise, at most I<size> bytes will be written, including the ending '\0',
 and I<buf> is returned.
 
-X509_NAME_print() prints out I<name> to I<bp> indenting each line by I<obase>
-characters. Multiple lines are used if the output (including indent) exceeds
-80 characters.
+X509_NAME_print() prints out I<name> to I<bp> with a limited attempt
+to make the output more readable.
+The I<dummy> parameter is an historical artificate and not used.
 
 =head1 NOTES
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -818,7 +818,7 @@ int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm, int indent,
                           unsigned long flags);
 # endif
 
-int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase);
+int X509_NAME_print(BIO *bp, const X509_NAME *name, int dummy);
 int X509_NAME_print_ex(BIO *out, const X509_NAME *nm, int indent,
                        unsigned long flags);
 int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflag,


### PR DESCRIPTION
Make clear what `X509_NAME_print` does.
Also try to make the code more obvious.

Fixes: #75

ping @davidben if you have a chance to take a look.  I will pass this along to OpenSSL once merged.
## Checklist
Thank you for your contribution. Please answer the following:

- [ ] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
