### PR TITLE
Keep but don't use, two pointless wrapper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,10 @@ data format have been removed.
 library number is dynamic not static.
   - The unused and undocumented `BIO_f_linebuffer`, `BIO_f_reliable`, and
 `BIO_s_log` now return NULL.
+  - Removed all uses of `X509_get_default_cert_dir_env` and
+`X09_get_default_cert_file_env` and just use the names documented
+in `doc/man7/openssl-env.pod` but kept the function for downstream
+compatibility.
 
 - Header files were reorganized:
   - The redundant `#pragma once` and old-style header guards were removed.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@ library number is dynamic not static.
   - The unused and undocumented `BIO_f_linebuffer`, `BIO_f_reliable`, and
 `BIO_s_log` now return NULL.
   - Removed all uses of `X509_get_default_cert_dir_env` and
-`X09_get_default_cert_file_env` and just use the names documented
+`X509_get_default_cert_file_env` and just use the names documented
 in `doc/man7/openssl-env.pod` but kept the function for downstream
 compatibility.
 

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -537,7 +537,7 @@ int rehash_main(int argc, char **argv)
     if (*argv != NULL) {
         while (*argv != NULL)
             errs += do_dir(*argv++, h);
-    } else if ((env = getenv(X509_get_default_cert_dir_env())) != NULL) {
+    } else if ((env = getenv(X509_CERT_DIR_EVP)) != NULL) {
         char lsc[2] = { LIST_SEPARATOR_CHAR, '\0' };
         m = OPENSSL_strdup(env);
         for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -79,7 +79,7 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
     switch (cmd) {
     case X509_L_ADD_DIR:
         if (argl == X509_FILETYPE_DEFAULT) {
-            const char *dir = ossl_safe_getenv(X509_get_default_cert_dir_env());
+            const char *dir = ossl_safe_getenv(X509_CERT_DIR_EVP);
 
             if (dir)
                 ret = add_cert_dir(ld, dir, X509_FILETYPE_PEM);

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -54,7 +54,7 @@ static int by_file_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
     switch (cmd) {
     case X509_L_FILE_LOAD:
         if (argl == X509_FILETYPE_DEFAULT) {
-            file = ossl_safe_getenv(X509_get_default_cert_file_env());
+            file = ossl_safe_getenv(X509_CERT_FILE_EVP);
             if (file)
                 ok = (X509_load_cert_crl_file_ex(ctx, file, X509_FILETYPE_PEM,
                                                  libctx, propq) != 0);

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -113,7 +113,7 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
     case X509_L_ADD_STORE:
         /* If no URI is given, use the default cert dir as default URI */
         if (argp == NULL)
-            argp = ossl_safe_getenv(X509_get_default_cert_dir_env());
+            argp = ossl_safe_getenv(X509_CERT_DIR_EVP);
 
         if (argp == NULL)
             argp = X509_get_default_cert_dir();

--- a/doc/man3/X509_get_default_cert_file.pod
+++ b/doc/man3/X509_get_default_cert_file.pod
@@ -32,8 +32,8 @@ The environment variable B<SSL_CERT_FILE>
 specifies a nondefault value to be used instead of the value
 returned by X509_get_default_cert_file(). The value returned by the latter
 function is not affected by these environment variables; you must check for this
-environment variable yourself, using this function to retrieve the correct
-environment variable name. If an environment variable is not set, the value
+environment variable yourself.
+If the environment variable is not set, the value
 returned by the X509_get_default_cert_file() should be used.
 
 =head1 BUGS

--- a/doc/man3/X509_get_default_cert_file.pod
+++ b/doc/man3/X509_get_default_cert_file.pod
@@ -2,9 +2,8 @@
 
 =head1 NAME
 
-X509_get_default_cert_file, X509_get_default_cert_file_env,
-X509_get_default_cert_dir, X509_get_default_cert_dir_env -
-retrieve default locations for trusted CA certificates
+X509_get_default_cert_file, X509_get_default_cert_dir
+- retrieve default locations for trusted CA certificates
 
 =head1 SYNOPSIS
 
@@ -12,9 +11,6 @@ retrieve default locations for trusted CA certificates
 
  const char *X509_get_default_cert_file(void);
  const char *X509_get_default_cert_dir(void);
-
- const char *X509_get_default_cert_file_env(void);
- const char *X509_get_default_cert_dir_env(void);
 
 =head1 DESCRIPTION
 
@@ -32,23 +28,18 @@ specified. If a given directory in the list exists, OpenSSL attempts to lookup
 CA certificates in this directory by calculating a filename based on a hash of
 the certificate's subject name.
 
-X509_get_default_cert_file_env() returns an environment variable name which is
-recommended to specify a nondefault value to be used instead of the value
+The environment variable B<SSL_CERT_FILE>
+specifies a nondefault value to be used instead of the value
 returned by X509_get_default_cert_file(). The value returned by the latter
 function is not affected by these environment variables; you must check for this
 environment variable yourself, using this function to retrieve the correct
 environment variable name. If an environment variable is not set, the value
 returned by the X509_get_default_cert_file() should be used.
 
-X509_get_default_cert_dir_env() returns the environment variable name which is
-recommended to specify a nondefault value to be used instead of the value
-returned by X509_get_default_cert_dir(). The value specified by this environment
-variable can also be a store URI (but see BUGS below).
-
 =head1 BUGS
 
 By default (for example, when L<X509_STORE_set_default_paths(3)> is used), the
-environment variable name returned by X509_get_default_cert_dir_env() is
+environment variable B<SSL_CERT_DIR> is
 interpreted both as a delimiter-separated list of paths, and as a store URI.
 This is ambiguous. For example, specifying a value of B<"file:///etc/certs">
 would cause instantiation of the "file" store provided as part of the default


### PR DESCRIPTION
These functions returned the names of documented environment variables

## Checklist
Thank you for your contribution. Please answer the following:

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
