### PR TITLE
Remove pre-ANSCI stringification

### DIFF
--- a/doc/man3/OPENSSL_FILE.pod
+++ b/doc/man3/OPENSSL_FILE.pod
@@ -2,8 +2,7 @@
 
 =head1 NAME
 
-OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC,
-OPENSSL_MSTR, OPENSSL_MSTR_HELPER
+OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC
 - generic C programming utility macros
 
 =head1 SYNOPSIS
@@ -13,9 +12,6 @@ OPENSSL_MSTR, OPENSSL_MSTR_HELPER
  #define OPENSSL_FILE /* typically: __FILE__ */
  #define OPENSSL_LINE /* typically: __LINE__ */
  #define OPENSSL_FUNC /* typically: __func__ */
-
- #define OPENSSL_MSTR_HELPER(x) #x
- #define OPENSSL_MSTR(x) OPENSSL_MSTR_HELPER(x)
 
 =head1 DESCRIPTION
 
@@ -27,10 +23,6 @@ The macro B<OPENSSL_FUNC> attempts to yield the name of the C function
 currently being compiled, as far as language and compiler versions allow.
 Otherwise, it yields "(unknown function)".
 
-The macro B<OPENSSL_MSTR> yields the expansion of the macro given as argument,
-which is useful for concatenation with string constants.
-The macro B<OPENSSL_MSTR_HELPER> is an auxiliary macro for this purpose.
-
 =head1 RETURN VALUES
 
 see above
@@ -41,8 +33,7 @@ L<crypto(7)>
 
 =head1 HISTORY
 
-B<OPENSSL_FUNC>, B<OPENSSL_MSTR>, and B<OPENSSL_MSTR_HELPER>
-were added in OpenSSL 3.0.
+B<OPENSSL_FUNC> was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -1099,16 +1099,19 @@ static void dump_digest_info(void)
 #define DEVCRYPTO_CMD_DIGESTS (ENGINE_CMD_BASE + 2)
 #define DEVCRYPTO_CMD_DUMP_INFO (ENGINE_CMD_BASE + 3)
 
+# define STR_HELPER(x) #x
+# define STR(x) STR_HELPER(x)
+
 static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
 #if defined(CIOCGSESSINFO) || defined(CIOCGSESSION2)
    {DEVCRYPTO_CMD_USE_SOFTDRIVERS,
     "USE_SOFTDRIVERS",
     "specifies whether to use software (not accelerated) drivers ("
-        OPENSSL_MSTR(DEVCRYPTO_REQUIRE_ACCELERATED) "=use only accelerated drivers, "
-        OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
-        OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
+        STR(DEVCRYPTO_REQUIRE_ACCELERATED) "=use only accelerated drivers, "
+        STR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
+        STR(DEVCRYPTO_REJECT_SOFTWARE)
         "=use if acceleration can't be determined) [default="
-        OPENSSL_MSTR(DEVCRYPTO_DEFAULT_USE_SOFTDRIVERS) "]",
+        STR(DEVCRYPTO_DEFAULT_USE_SOFTDRIVERS) "]",
     ENGINE_CMD_FLAG_NUMERIC},
 #endif
 

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -14,9 +14,6 @@
 #include <openssl/opensslv.h>
 
 
-/* Helper macros for CPP string composition */
-# define OPENSSL_MSTR_HELPER(x) #x
-# define OPENSSL_MSTR(x) OPENSSL_MSTR_HELPER(x)
 
 /*
  * Sometimes OPENSSL_NO_xxx ends up with an empty file and some compilers

--- a/util/other.syms
+++ b/util/other.syms
@@ -396,8 +396,6 @@ OCSP_set_max_response_length            define deprecated 3.0.0
 OPENSSL_FILE                            define
 OPENSSL_FUNC                            define
 OPENSSL_LINE                            define
-OPENSSL_MSTR                            define
-OPENSSL_MSTR_HELPER                     define
 OPENSSL_VERSION_MAJOR                   define
 OPENSSL_VERSION_MINOR                   define
 OPENSSL_VERSION_NUMBER                  define
@@ -449,8 +447,6 @@ OSSL_CMP_LOG_INFO                       define
 OSSL_CMP_LOG_NOTICE                     define
 OSSL_CMP_LOG_TRACE                      define
 OSSL_CMP_LOG_WARNING                    define
-OSSL_CMP_MSTR_HELPER                    define
-OSSL_CMP_MSTR                           define
 OSSL_CMP_P10CR                          define
 OSSL_CMP_certConf_cb_t                  datatype
 OSSL_CMP_log_cb_t                       datatype


### PR DESCRIPTION
Finding little things as I go through cmake-conversion and seeing what can be tossed.

## Checklist
Thank you for your contribution. Please answer the following:

- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
