### PR TITLE
Some keylog improvements

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -383,7 +383,7 @@ static int test_keylog(void)
         goto end;
 # if !defined(OPENSSL_NO_SSLKEYLOG_CB)
     clean_log_space();
-    struct sslapitest_log_counts expected;
+    struct sslapitest_log_counts expected = {0};
 
     SSL_CTX_set_keylog_callback(cctx, client_keylog_callback);
     if (!TEST_true(SSL_CTX_get_keylog_callback(cctx)
@@ -441,7 +441,7 @@ static int test_keylog_no_master_key(void)
     SSL *clientssl = NULL, *serverssl = NULL;
     SSL_SESSION *sess = NULL;
     int testresult = 0;
-    struct sslapitest_log_counts expected;
+    struct sslapitest_log_counts expected = {0};
     unsigned char buf[1];
     size_t readbytes, written;
 


### PR DESCRIPTION
There are three parts to this:
- Avoid use of uninitialized that resulted in weird test failures
- Use a secmem BIO to assemble the keylog line in slightly more modern C style
- Add error checking to the do_sslkeylog() function
I'm not 100% certain about the last one, but it feels wrong to silently ignore keylogging errors since people have explicitly opted into using this debugging feature. Clearly we can't fix the keylog callback in that regard.

## Checklist
Thank you for your contribution. Please answer the following:

- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] All new public APIs are documented
- [ ] All new public functions have tests
- [ ] All new public functions have fuzzing tests
