### PR TITLE
Add -fno-sanitize=function to CI

### DIFF
--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -25,7 +25,7 @@ jobs:
             cc: afl-clang-fast
           }, {
             name: libFuzzer,
-            config: enable-fuzz-libfuzzer enable-asan enable-ubsan,
+            config: enable-fuzz-libfuzzer enable-asan enable-ubsan -fno-sanitize=function,
             libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/include/clang/12/include/fuzzer,
             install: libfuzzer-12-dev,
             cc: clang-12,
@@ -33,7 +33,7 @@ jobs:
             tests: -test_memleak
           }, {
             name: libFuzzer+,
-            config: enable-fuzz-libfuzzer enable-asan enable-ubsan -fsanitize-coverage=trace-cmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION,
+            config: enable-fuzz-libfuzzer enable-asan enable-ubsan -fno-sanitize=function -fsanitize-coverage=trace-cmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION,
             libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/include/clang/12/include/fuzzer,
             extra: enable-ec_nistp_64_gcc_128 -fno-sanitize=alignment enable-weak-ssl-ciphers enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method,
             install: libfuzzer-12-dev,

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -259,7 +259,7 @@ jobs:
         sudo cat /proc/sys/vm/mmap_rnd_bits
         sudo sysctl -w vm.mmap_rnd_bits=28
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-brotli -DPEDANTIC && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan -fno-sanitize=function enable-comp enable-brotli -DPEDANTIC && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info
@@ -285,7 +285,7 @@ jobs:
         sudo cat /proc/sys/vm/mmap_rnd_bits
         sudo sysctl -w vm.mmap_rnd_bits=28
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-zstd -DPEDANTIC && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan -fno-sanitize=function enable-comp enable-zstd -DPEDANTIC && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
-          enable-asan enable-ubsan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
+          enable-asan enable-ubsan -fno-sanitize=function no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
           no-ct,
           no-dso,
           no-dynamic-engine,
           no-engine no-shared,
           no-err,
           no-filenames,
-          enable-ubsan no-asm -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment,
+          enable-ubsan no-asm -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment -fno-sanitize=function,
           no-module,
           no-ocsp,
           no-pinshared,


### PR DESCRIPTION
This does not report indirect calls of a function through a function pointer of the wrong type. This UB pattern is present at least in the stack and lhash code and should be fixed. BoringSSL has fixes, but it isn't pretty. Until a solution is chosen, we want CI to work.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
