### PR TITLE
More ci fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   external-tests:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-22.04' || 'ubuntu-22.04-self-hosted' }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -29,7 +29,7 @@ jobs:
             extra_config: no-afalgeng enable-tfo
           }
         ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository_owner == 'quictls' || github.event_name != 'schedule' }}
     steps:
     - uses: actions/checkout@v4

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
      */
     int exitcode = EXIT_FAILURE;
 #endif
-    char *lost;
+    char *volatile lost;
 
     lost = OPENSSL_malloc(3);
     if (!TEST_ptr(lost))


### PR DESCRIPTION
This pulls in a fix for the memleak test from upstream and pins the two tests involving krb5 to ubuntu 22.04 since that needs older python for now.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
