### PR TITLE
Minor doc nits

### DIFF
--- a/doc/man3/ASN1_OBJECT_new.pod
+++ b/doc/man3/ASN1_OBJECT_new.pod
@@ -33,8 +33,6 @@ If the allocation fails, ASN1_OBJECT_new() returns NULL and sets an error
 code that can be obtained by L<ERR_get_error(3)>.
 Otherwise it returns a pointer to the newly allocated structure.
 
-ASN1_OBJECT_free() returns no value.
-
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>, L<d2i_ASN1_OBJECT(3)>

--- a/doc/man3/BN_mod_exp_mont.pod
+++ b/doc/man3/BN_mod_exp_mont.pod
@@ -51,7 +51,7 @@ The error codes can be obtained by L<ERR_get_error(3)>.
 
 =head1 SEE ALSO
 
-L<ERR_get_error(3)>, L<BN_mod_exp_mont(3)>
+L<ERR_get_error(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BN_zero.pod
+++ b/doc/man3/BN_zero.pod
@@ -37,7 +37,6 @@ be represented as a single integer.
 
 BN_one() and BN_set_word() return 1 on success, 0 otherwise.
 BN_value_one() returns the constant.
-BN_zero() never fails and returns no value.
 
 =head1 BUGS
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -144,8 +144,6 @@ CRYPTO_THREAD_run_once() returns 1 on success, or 0 on error.
 
 CRYPTO_THREAD_lock_new() returns the allocated lock, or NULL on error.
 
-CRYPTO_THREAD_lock_free() returns no value.
-
 OSSL_set_max_threads() returns 1 on success and 0 on failure. Returns failure
 if OpenSSL-managed thread pooling is not supported (for example, if it is not
 supported on the current platform, or because OpenSSL is not built with the

--- a/doc/man3/DH_new.pod
+++ b/doc/man3/DH_new.pod
@@ -34,7 +34,7 @@ DH_free() returns no value.
 
 =head1 SEE ALSO
 
-L<DH_new(3)>, L<ERR_get_error(3)>,
+L<ERR_get_error(3)>,
 L<DH_generate_parameters_ex(3)>,
 L<DH_generate_key(3)>,
 L<EVP_PKEY-DH(7)>

--- a/doc/man3/DH_new.pod
+++ b/doc/man3/DH_new.pod
@@ -30,8 +30,6 @@ If the allocation fails, DH_new() returns B<NULL> and sets an error
 code that can be obtained by L<ERR_get_error(3)>. Otherwise it returns
 a pointer to the newly allocated structure.
 
-DH_free() returns no value.
-
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>,

--- a/doc/man3/DH_set_method.pod
+++ b/doc/man3/DH_set_method.pod
@@ -69,8 +69,6 @@ L<DH_meth_new(3)>).
 DH_OpenSSL() and DH_get_default_method() return pointers to the respective
 B<DH_METHOD>s.
 
-DH_set_default_method() returns no value.
-
 DH_set_method() returns nonzero if the provided B<meth> was successfully set as
 the method for B<dh> (including unloading the ENGINE handle if the previous
 method was supplied by an ENGINE).

--- a/doc/man3/DSA_SIG_new.pod
+++ b/doc/man3/DSA_SIG_new.pod
@@ -37,8 +37,6 @@ error code that can be obtained by
 L<ERR_get_error(3)>. Otherwise it returns a pointer
 to the newly allocated structure.
 
-DSA_SIG_free() returns no value.
-
 DSA_SIG_set0() returns 1 on success or 0 on failure.
 
 =head1 SEE ALSO

--- a/doc/man3/DSA_new.pod
+++ b/doc/man3/DSA_new.pod
@@ -35,8 +35,6 @@ code that can be obtained by
 L<ERR_get_error(3)>. Otherwise it returns a pointer
 to the newly allocated structure.
 
-DSA_free() returns no value.
-
 =head1 SEE ALSO
 
 L<EVP_PKEY_new(3)>, L<EVP_PKEY_free(3)>,

--- a/doc/man3/DSA_new.pod
+++ b/doc/man3/DSA_new.pod
@@ -40,7 +40,7 @@ DSA_free() returns no value.
 =head1 SEE ALSO
 
 L<EVP_PKEY_new(3)>, L<EVP_PKEY_free(3)>,
-L<DSA_new(3)>, L<ERR_get_error(3)>,
+L<ERR_get_error(3)>,
 L<DSA_generate_parameters_ex(3)>,
 L<DSA_generate_key(3)>
 

--- a/doc/man3/ERR_load_strings.pod
+++ b/doc/man3/ERR_load_strings.pod
@@ -44,7 +44,7 @@ library number.
 
 =head1 SEE ALSO
 
-L<ERR_load_strings(3)>
+L<ERR_error_string(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -75,8 +75,6 @@ obtained by L<ERR_get_error(3)>.
 =head1 SEE ALSO
 
 L<RAND_add(3)>,
-L<RAND_bytes(3)>,
-L<RAND_priv_bytes(3)>,
 L<ERR_get_error(3)>,
 L<RAND(7)>,
 L<EVP_RAND(7)>

--- a/doc/man3/RSA_blinding_on.pod
+++ b/doc/man3/RSA_blinding_on.pod
@@ -35,8 +35,6 @@ the blinding factor.
 
 RSA_blinding_on() returns 1 on success, and 0 if an error occurred.
 
-RSA_blinding_off() returns no value.
-
 =head1 HISTORY
 
 All of these functions were deprecated in OpenSSL 3.0.

--- a/doc/man3/RSA_new.pod
+++ b/doc/man3/RSA_new.pod
@@ -31,8 +31,6 @@ If the allocation fails, RSA_new() returns B<NULL> and sets an error
 code that can be obtained by L<ERR_get_error(3)>. Otherwise it returns
 a pointer to the newly allocated structure.
 
-RSA_free() returns no value.
-
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>,

--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -146,8 +146,6 @@ the default method is used.
 RSA_PKCS1_OpenSSL(), RSA_PKCS1_null_method(), RSA_get_default_method()
 and RSA_get_method() return pointers to the respective RSA_METHODs.
 
-RSA_set_default_method() returns no value.
-
 RSA_set_method() returns a pointer to the old RSA_METHOD implementation
 that was replaced. However, this return value should probably be ignored
 because if it was supplied by an ENGINE, the pointer could be invalidated

--- a/doc/man3/SMIME_read_PKCS7.pod
+++ b/doc/man3/SMIME_read_PKCS7.pod
@@ -68,7 +68,7 @@ or B<NULL> if an error occurred. The error can be obtained from ERR_get_error(3)
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>,
-L<SMIME_read_PKCS7(3)>, L<PKCS7_sign(3)>,
+L<PKCS7_sign(3)>,
 L<PKCS7_verify(3)>, L<PKCS7_encrypt(3)>
 L<PKCS7_decrypt(3)>
 

--- a/doc/man3/SSL_get_default_timeout.pod
+++ b/doc/man3/SSL_get_default_timeout.pod
@@ -35,8 +35,7 @@ See description.
 L<ssl(7)>,
 L<SSL_CTX_set_session_cache_mode(3)>,
 L<SSL_SESSION_get_time(3)>,
-L<SSL_CTX_flush_sessions(3)>,
-L<SSL_get_default_timeout(3)>
+L<SSL_CTX_flush_sessions(3)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
- There's no reason to list functions in the current manual in SEE ALSO.
- Some void functions are documented as returning nothing. This is pointless.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
