### PR TITLE
Move struct to internal header

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -17,7 +17,7 @@
 #include <openssl/trace.h>
 #include <crypto/evp.h>
 #include <crypto/decoder.h>
-#include "crypto/evp/evp_local.h"
+#include <internal/evp.h>
 #include <crypto/lhash.h>
 #include "encoder_local.h"
 #include <internal/namemap.h>

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -9,6 +9,7 @@
 
 #include <openssl/core_dispatch.h>
 #include <internal/refcount.h>
+#include <internal/evp.h>
 
 #define EVP_CTRL_RET_UNSUPPORTED -1
 
@@ -90,52 +91,6 @@ struct evp_rand_ctx_st {
     CRYPTO_REF_COUNT refcnt;    /* Context reference count */
     CRYPTO_RWLOCK *refcnt_lock;
 } /* EVP_RAND_CTX */ ;
-
-struct evp_keymgmt_st {
-    int id;                      /* libcrypto internal */
-
-    int name_id;
-    /* NID for the legacy alg if there is one */
-    int legacy_alg;
-    char *type_name;
-    const char *description;
-    OSSL_PROVIDER *prov;
-    CRYPTO_REF_COUNT refcnt;
-
-    /* Constructor(s), destructor, information */
-    OSSL_FUNC_keymgmt_new_fn *new;
-    OSSL_FUNC_keymgmt_free_fn *free;
-    OSSL_FUNC_keymgmt_get_params_fn *get_params;
-    OSSL_FUNC_keymgmt_gettable_params_fn *gettable_params;
-    OSSL_FUNC_keymgmt_set_params_fn *set_params;
-    OSSL_FUNC_keymgmt_settable_params_fn *settable_params;
-
-    /* Generation, a complex constructor */
-    OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
-    OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
-    OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
-    OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
-    OSSL_FUNC_keymgmt_gen_fn *gen;
-    OSSL_FUNC_keymgmt_gen_cleanup_fn *gen_cleanup;
-
-    OSSL_FUNC_keymgmt_load_fn *load;
-
-    /* Key object checking */
-    OSSL_FUNC_keymgmt_query_operation_name_fn *query_operation_name;
-    OSSL_FUNC_keymgmt_has_fn *has;
-    OSSL_FUNC_keymgmt_validate_fn *validate;
-    OSSL_FUNC_keymgmt_match_fn *match;
-
-    /* Import and export routines */
-    OSSL_FUNC_keymgmt_import_fn *import;
-    OSSL_FUNC_keymgmt_import_types_fn *import_types;
-    OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
-    OSSL_FUNC_keymgmt_export_fn *export;
-    OSSL_FUNC_keymgmt_export_types_fn *export_types;
-    OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
-    OSSL_FUNC_keymgmt_dup_fn *dup;
-} /* EVP_KEYMGMT */ ;
-
 struct evp_keyexch_st {
     int name_id;
     char *type_name;

--- a/include/internal/evp.h
+++ b/include/internal/evp.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#ifndef OSSL_INTERNAL_EVP_H
+# define OSSL_INTERNAL_EVP_H
+
+struct evp_keymgmt_st {
+    int id;                      /* libcrypto internal */
+
+    int name_id;
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+    char *type_name;
+    const char *description;
+    OSSL_PROVIDER *prov;
+    CRYPTO_REF_COUNT refcnt;
+
+    /* Constructor(s), destructor, information */
+    OSSL_FUNC_keymgmt_new_fn *new;
+    OSSL_FUNC_keymgmt_free_fn *free;
+    OSSL_FUNC_keymgmt_get_params_fn *get_params;
+    OSSL_FUNC_keymgmt_gettable_params_fn *gettable_params;
+    OSSL_FUNC_keymgmt_set_params_fn *set_params;
+    OSSL_FUNC_keymgmt_settable_params_fn *settable_params;
+
+    /* Generation, a complex constructor */
+    OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
+    OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+    OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
+    OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
+    OSSL_FUNC_keymgmt_gen_fn *gen;
+    OSSL_FUNC_keymgmt_gen_cleanup_fn *gen_cleanup;
+
+    OSSL_FUNC_keymgmt_load_fn *load;
+
+    /* Key object checking */
+    OSSL_FUNC_keymgmt_query_operation_name_fn *query_operation_name;
+    OSSL_FUNC_keymgmt_has_fn *has;
+    OSSL_FUNC_keymgmt_validate_fn *validate;
+    OSSL_FUNC_keymgmt_match_fn *match;
+
+    /* Import and export routines */
+    OSSL_FUNC_keymgmt_import_fn *import;
+    OSSL_FUNC_keymgmt_import_types_fn *import_types;
+    OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
+    OSSL_FUNC_keymgmt_export_fn *export;
+    OSSL_FUNC_keymgmt_export_types_fn *export_types;
+    OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
+    OSSL_FUNC_keymgmt_dup_fn *dup;
+} /* EVP_KEYMGMT */ ;
+
+#endif


### PR DESCRIPTION
decoder_pkey needs EVP_KEYMGMT structure, so move it from evp_local.h to a new internal/evp.h header file

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
