### PR TITLE
Update Ubuntu

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -18,18 +18,24 @@ jobs:
       fail-fast: false
       matrix:
         zoo: [
+        # - we set gcc-ppc-name if the GCC version isn't
+        # part of the Ubuntu version we're using (see
+        # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test).
           {
-            cc: gcc-7,
-            distro: ubuntu-20.04
+            cc: gcc-11,
+            distro: ubuntu-22.04
           }, {
             cc: gcc-13,
             distro: ubuntu-22.04,
             gcc-ppa-name: ubuntu-toolchain-r/test
           }, {
-            cc: clang-6.0,
-            distro: ubuntu-20.04
+        # Set llvm-ppa-name if an LLVM version isn't part of the
+        # Ubuntu version we're using (see https://apt.llvm.org/).
+            cc: clang-18,
+            distro: ubuntu-22.04,
+            llvm-ppa-name: jammy
           }, {
-            cc: clang-17,
+            cc: clang-19,
             distro: ubuntu-22.04,
             llvm-ppa-name: jammy
           }
@@ -45,8 +51,6 @@ jobs:
         llvm_ppa_name="${{ matrix.zoo.llvm-ppa-name }}"
 
         # In the Matrix above:
-        # - we set gcc-ppc-name if the GCC version isn't part of the Ubuntu version we're using (see https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test).
-        # - we set llvm-ppa-name if an LLVM version isn't part of the Ubuntu version we're using (see https://apt.llvm.org/).
         # This is especially needed because even new Ubuntu LTSes aren't available
         # until a while after release on Github Actions.
         if [[ -n ${gcc_ppa_name} ]] ; then


### PR DESCRIPTION
GitHub is removing the Ubuntu 20.04 image by April 1.

Not sure if the early compilers are supported on 22.04, so let's see how the CI does.
The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
