### PR TITLE
Remove duplicate options

### DIFF
--- a/doc/man1/openssl-s_client.podin
+++ b/doc/man1/openssl-s_client.podin
@@ -57,7 +57,6 @@ B<openssl> B<s_client>
 [B<-msg>]
 [B<-timeout>]
 [B<-mtu> I<size>]
-[B<-no_etm>]
 [B<-no_ems>]
 [B<-keymatexport> I<label>]
 [B<-keymatexportlen> I<len>]
@@ -79,27 +78,14 @@ B<openssl> B<s_client>
 [B<-max_pipelines>]
 [B<-read_buf>]
 [B<-ignore_unexpected_eof>]
-[B<-bugs>]
 [B<-no_tx_cert_comp>]
 [B<-no_rx_cert_comp>]
-[B<-comp>]
-[B<-no_comp>]
 [B<-brief>]
-[B<-legacy_server_connect>]
-[B<-no_legacy_server_connect>]
-[B<-allow_no_dhe_kex>]
-[B<-prefer_no_dhe_kex>]
-[B<-sigalgs> I<sigalglist>]
-[B<-curves> I<curvelist>]
-[B<-cipher> I<cipherlist>]
-[B<-ciphersuites> I<val>]
-[B<-serverpref>]
 [B<-starttls> I<protocol>]
 [B<-name> I<hostname>]
 [B<-xmpphost> I<hostname>]
 [B<-name> I<hostname>]
 [B<-tlsextdebug>]
-[B<-no_ticket>]
 [B<-sess_out> I<filename>]
 [B<-serverinfo> I<types>]
 [B<-sess_in> I<filename>]
@@ -458,10 +444,6 @@ Enable send/receive timeout on DTLS connections.
 
 Set MTU of the link layer to the specified size.
 
-=item B<-no_etm>
-
-Disable Encrypt-then-MAC negotiation.
-
 =item B<-no_ems>
 
 Disable Extended master secret negotiation.
@@ -578,11 +560,6 @@ option is enabled the peer does not need to send the close_notify alert and a
 closed connection will be treated as if the close_notify alert was received.
 For more information on shutting down a connection, see L<SSL_shutdown(3)>.
 
-=item B<-bugs>
-
-There are several known bugs in SSL and TLS implementations. Adding this
-option enables various workarounds.
-
 =item B<-no_tx_cert_comp>
 
 Disables support for sending TLSv1.3 compressed certificates.
@@ -591,57 +568,10 @@ Disables support for sending TLSv1.3 compressed certificates.
 
 Disables support for receiving TLSv1.3 compressed certificate.
 
-=item B<-comp>
-
-Enables support for SSL/TLS compression.
-This option was introduced in OpenSSL 1.1.0.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0. TLS compression can only be used in security level 1 or
-lower. From OpenSSL 3.2.0 and above the default security level is 2, so this
-option will have no effect without also changing the security level. Use the
-B<-cipher> option to change the security level. See L<openssl-ciphers(1)> for
-more information.
-
-=item B<-no_comp>
-
-Disables support for SSL/TLS compression.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
-
 =item B<-brief>
 
 Only provide a brief summary of connection parameters instead of the
 normal verbose output.
-
-=item B<-sigalgs> I<sigalglist>
-
-Specifies the list of signature algorithms that are sent by the client.
-The server selects one entry in the list based on its preferences.
-For example strings, see L<SSL_CTX_set1_sigalgs(3)>
-
-=item B<-curves> I<curvelist>
-
-Specifies the list of supported curves to be sent by the client. The curve is
-ultimately selected by the server. For a list of all curves, use:
-
-    $ openssl ecparam -list_curves
-
-=item B<-cipher> I<cipherlist>
-
-This allows the TLSv1.2 and below cipher list sent by the client to be modified.
-This list will be combined with any TLSv1.3 ciphersuites that have been
-configured. Although the server determines which ciphersuite is used it should
-take the first supported cipher in the list sent by the client. See
-L<openssl-ciphers(1)> for more information.
-
-=item B<-ciphersuites> I<val>
-
-This allows the TLSv1.3 ciphersuites sent by the client to be modified. This
-list will be combined with any TLSv1.2 and below ciphersuites that have been
-configured. Although the server determines which cipher suite is used it should
-take the first supported cipher in the list sent by the client. See
-L<openssl-ciphers(1)> for more information. The format for this list is a simple
-colon (":") separated list of TLSv1.3 ciphersuite names.
 
 =item B<-starttls> I<protocol>
 
@@ -676,10 +606,6 @@ this option is not specified, then "mail.example.com" will be used.
 =item B<-tlsextdebug>
 
 Print out a hex dump of any TLS extensions received from the server.
-
-=item B<-no_ticket>
-
-Disable RFC4507bis session ticket support.
 
 =item B<-sess_out> I<filename>
 

--- a/doc/man1/openssl-s_server.podin
+++ b/doc/man1/openssl-s_server.podin
@@ -68,7 +68,6 @@ B<openssl> B<s_server>
 [B<-verify_quiet>]
 [B<-ign_eof>]
 [B<-no_ign_eof>]
-[B<-no_etm>]
 [B<-no_ems>]
 [B<-status>]
 [B<-status_verbose>]
@@ -89,30 +88,9 @@ B<openssl> B<s_server>
 [B<-max_pipelines> I<+int>]
 [B<-naccept> I<+int>]
 [B<-read_buf> I<+int>]
-[B<-bugs>]
 [B<-no_tx_cert_comp>]
 [B<-no_rx_cert_comp>]
-[B<-no_comp>]
-[B<-comp>]
-[B<-no_ticket>]
-[B<-serverpref>]
-[B<-legacy_renegotiation>]
-[B<-no_renegotiation>]
-[B<-no_resumption_on_reneg>]
-[B<-allow_no_dhe_kex>]
-[B<-prefer_no_dhe_kex>]
-[B<-prioritize_chacha>]
-[B<-strict>]
-[B<-sigalgs> I<val>]
-[B<-client_sigalgs> I<val>]
-[B<-groups> I<val>]
-[B<-curves> I<val>]
-[B<-named_curve> I<val>]
-[B<-cipher> I<val>]
-[B<-ciphersuites> I<val>]
 [B<-dhparam> I<infile>]
-[B<-record_padding> I<val>]
-[B<-debug_broken_protocol>]
 [B<-nbio>]
 [B<-psk_identity> I<val>]
 [B<-psk_hint> I<val>]
@@ -600,11 +578,6 @@ effect if the buffer size is larger than the size that would otherwise be used
 and pipelining is in use (see L<SSL_CTX_set_default_read_buffer_len(3)> for
 further information).
 
-=item B<-bugs>
-
-There are several known bugs in SSL and TLS implementations. Adding this
-option enables various workarounds.
-
 =item B<-no_tx_cert_comp>
 
 Disables support for sending TLSv1.3 compressed certificates.
@@ -613,76 +586,15 @@ Disables support for sending TLSv1.3 compressed certificates.
 
 Disables support for receiving TLSv1.3 compressed certificates.
 
-=item B<-no_comp>
-
-Disable negotiation of TLS compression.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
-
-=item B<-comp>
-
-Enables support for SSL/TLS compression.
-This option was introduced in OpenSSL 1.1.0.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0. TLS compression can only be used in security level 1 or
-lower. From OpenSSL 3.2.0 and above the default security level is 2, so this
-option will have no effect without also changing the security level. Use the
-B<-cipher> option to change the security level. See L<openssl-ciphers(1)> for
-more information.
-
-=item B<-no_ticket>
-
-Disable RFC4507bis session ticket support. This option has no effect if TLSv1.3
-is negotiated. See B<-num_tickets>.
-
 =item B<-num_tickets>
 
 Control the number of tickets that will be sent to the client after a full
 handshake in TLSv1.3. The default number of tickets is 2. This option does not
 affect the number of tickets sent after a resumption handshake.
 
-=item B<-serverpref>
-
-Use the server's cipher preferences, rather than the client's preferences.
-
-=item B<-prioritize_chacha>
-
-Prioritize ChaCha ciphers when preferred by clients. Requires B<-serverpref>.
-
 =item B<-no_resumption_on_reneg>
 
 Set the B<SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION> option.
-
-=item B<-client_sigalgs> I<val>
-
-Signature algorithms to support for client certificate authentication
-(colon-separated list).
-
-=item B<-named_curve> I<val>
-
-Specifies the elliptic curve to use. NOTE: this is single curve, not a list.
-For a list of all possible curves, use:
-
-    $ openssl ecparam -list_curves
-
-=item B<-cipher> I<val>
-
-This allows the list of TLSv1.2 and below ciphersuites used by the server to be
-modified. This list is combined with any TLSv1.3 ciphersuites that have been
-configured. When the client sends a list of supported ciphers the first client
-cipher also included in the server list is used. Because the client specifies
-the preference order, the order of the server cipherlist is irrelevant. See
-L<openssl-ciphers(1)> for more information.
-
-=item B<-ciphersuites> I<val>
-
-This allows the list of TLSv1.3 ciphersuites used by the server to be modified.
-This list is combined with any TLSv1.2 and below ciphersuites that have been
-configured. When the client sends a list of supported ciphers the first client
-cipher also included in the server list is used. Because the client specifies
-the preference order, the order of the server cipherlist is irrelevant. See
-L<openssl-ciphers(1)> command for more information. The format for this list is
-a simple colon (":") separated list of TLSv1.3 ciphersuite names.
 
 =item B<-dhparam> I<infile>
 


### PR DESCRIPTION
Remove from synopsis and, where present, from text.

In response to OpenSSL issue 11748, and Chase Killorin's partial fix.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
