### PR TITLE
Remove unused assignment

### DIFF
--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -63,9 +63,6 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     if (wrap_nid <= 0)
         wrap_nid = NID_id_alg_PWRI_KEK;
 
-    if (pbe_nid <= 0)
-        pbe_nid = NID_id_pbkdf2;
-
     /* Get from enveloped data */
     if (kekciph == NULL)
         kekciph = ec->cipher;


### PR DESCRIPTION
From OpenSSL PR 27296 by Kenzlee51

This should really remove the parameter completely, but that changes the public API, even though not documented. Sigh.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
