### PR TITLE
Clarify SSL_CTX_set_min_proto_version defaults

### DIFF
--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -31,9 +31,11 @@ L<SSL_CTX_set_options(3)> that also make it possible to disable
 specific protocol versions.
 Use these functions instead of disabling specific protocol versions.
 
-Setting the minimum or maximum version to 0, will enable protocol
+Setting the minimum or maximum version to 0 (the default), will
+enable protocol
 versions down to the lowest version, or up to the highest version
-supported by the library, respectively.
+supported by the library, respectively. The supported versions might be
+controlled by system configuration.
 
 Getters return 0 in case B<ctx> or B<ssl> have been configured to
 automatically use the lowest or highest version supported by the library.


### PR DESCRIPTION
From OpenSSL PR 27401 by Norbert Pocs

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
