### PR TITLE
Update setup-nasm CI task

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -141,7 +141,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.platform.arch }}
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
       with:
         platform: ${{ matrix.platform.arch }}
     - name: prepare the build directory

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -26,7 +26,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd
@@ -68,7 +68,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
     - name: prepare the build directory
       run: mkdir _build
     - name: Get brotli


### PR DESCRIPTION
The new version works around the fact that www.nasm.us is down by trying mirrors.

Fix from OpenSSL PR #27425 by nhorman

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
