### PR TITLE
Make CA.pl system() calls more robust

### DIFF
--- a/extras/test/recipes/80-test_ca.t
+++ b/extras/test/recipes/80-test_ca.t
@@ -21,9 +21,7 @@ setup("test_ca");
 $ENV{OPENSSL} = cmdstr(app(["openssl"]), display => 1);
 
 my $cnf = srctop_file("test","ca-and-certs.cnf");
-my $std_openssl_cnf = '"'
-    . srctop_file("apps", "openssl.cnf")
-    . '"';
+my $std_openssl_cnf = . srctop_file("apps", "openssl.cnf");
 
 sub src_file {
     return srctop_file("test", "certs", shift);
@@ -37,19 +35,19 @@ require_ok(srctop_file("test", "recipes", "tconversion.pl"));
 
  SKIP: {
      my $cakey = src_file("ca-key.pem");
-     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
+     $ENV{OPENSSL_CONFIG} = qq(-config $cnf);
      skip "failed creating CA structure", 4
          if !ok(run(perlapp(["CA.pl","-newca",
                              "-extra-req", "-key $cakey"], stdin => undef)),
                 'creating CA structure');
 
      my $eekey = src_file("ee-key.pem");
-     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
+     $ENV{OPENSSL_CONFIG} = qq(-config $cnf);
      skip "failed creating new certificate request", 3
          if !ok(run(perlapp(["CA.pl","-newreq",
                              '-extra-req', "-outform DER -section userreq -key $eekey"])),
                 'creating certificate request');
-     $ENV{OPENSSL_CONFIG} = qq(-rand_serial -inform DER -config "$std_openssl_cnf");
+     $ENV{OPENSSL_CONFIG} = qq(-rand_serial -inform DER -config $std_openssl_cnf);
      skip "failed to sign certificate request", 2
          if !is(yes(cmdstr(perlapp(["CA.pl", "-sign"]))), 0,
                 'signing certificate request');
@@ -61,7 +59,7 @@ require_ok(srctop_file("test", "recipes", "tconversion.pl"));
          if disabled("ct");
 
      my $eekey2 = src_file("ee-key-3072.pem");
-     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
+     $ENV{OPENSSL_CONFIG} = qq(-config $cnf);
      ok(run(perlapp(["CA.pl", "-precert", '-extra-req', "-section userreq -key $eekey2"], stderr => undef)),
         'creating new pre-certificate');
 }


### PR DESCRIPTION
The CA.pl script used to build single-string string commandlines to pass to a shell via system(command_string). That was fragile and not a best practice.  This PR replaces system(command_string) with system { executable } @argv, which avoids the shell whenever possible (at least Unix-like systems and Windows).

Ported from OpenSSL PR #27432 by Viktor Dukhovni

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
