### PR TITLE
Fix parameter value output

### DIFF
--- a/apps/lib/app_params.c
+++ b/apps/lib/app_params.c
@@ -9,13 +9,14 @@
 
 #include <apps/apps.h>
 
+/* Maximum number of bytes that will be output for an octet string body */
+#define MAX_OCTET_STRING_OUTPUT_BYTES 24
+
 static int describe_param_type(char *buf, size_t bufsz, const OSSL_PARAM *param)
 {
+    int show_type_number = 0;
     const char *type_mod = "";
     const char *type = NULL;
-    int show_type_number = 0;
-    int printed_len;
-
     switch (param->data_type) {
     case OSSL_PARAM_UNSIGNED_INTEGER:
         type_mod = "unsigned ";
@@ -41,7 +42,7 @@ static int describe_param_type(char *buf, size_t bufsz, const OSSL_PARAM *param)
         break;
     }
 
-    printed_len = BIO_snprintf(buf, bufsz, "%s: ", param->key);
+    int printed_len = BIO_snprintf(buf, bufsz, "%s: ", param->key);
     if (printed_len > 0) {
         buf += printed_len;
         bufsz -= printed_len;
@@ -93,6 +94,56 @@ int print_param_types(const char *thing, const OSSL_PARAM *pdefs, int indent)
     return 1;
 }
 
+/* Output the body of a UTF8 string which might not be zero terminated */
+static void print_param_utf8(const char **s_ptr, size_t len)
+{
+    if (s_ptr == NULL) {
+        BIO_puts(bio_out, " ptr null\n");
+        return;
+    }
+
+    const char *s = *s_ptr;
+    if (s == NULL) {
+        BIO_puts(bio_out, " null\n");
+        return;
+    }
+    BIO_puts(bio_out, "'");
+    if (len > 0)
+        BIO_write(bio_out, s, len);
+    BIO_puts(bio_out, "'\n");
+}
+
+/* Output the body of an OCTET string */
+static void print_param_octet(const unsigned char **bytes_ptr, size_t len)
+{
+    size_t i;
+
+    BIO_printf(bio_out, "<%zu bytes>", len);
+    if (bytes_ptr == NULL) {
+        BIO_puts(bio_out, " ptr null\n");
+        return;
+    }
+    const unsigned char *bytes = *bytes_ptr;
+    if (bytes == NULL) {
+        BIO_puts(bio_out, " null\n");
+        return;
+    }
+    if (len == 0) {
+        BIO_puts(bio_out, "\n");
+        return;
+    }
+
+    const char *tail = "\n";
+    if (len > MAX_OCTET_STRING_OUTPUT_BYTES) {
+        len = MAX_OCTET_STRING_OUTPUT_BYTES;
+        tail = "...\n";
+    }
+    BIO_puts(bio_out, " ");
+    for (i = 0; i < len; i++)
+        BIO_printf(bio_out, "%02x", bytes[i]);
+    BIO_puts(bio_out, tail);
+}
+
 void print_param_value(const OSSL_PARAM *p, int indent)
 {
     int64_t i;
@@ -113,19 +164,20 @@ void print_param_value(const OSSL_PARAM *p, int indent)
             BIO_printf(bio_out, "error getting value\n");
         break;
     case OSSL_PARAM_UTF8_PTR:
-        BIO_printf(bio_out, "'%s'\n", *(char **)(p->data));
+        print_param_utf8((const char **)p->data, p->return_size);
         break;
     case OSSL_PARAM_UTF8_STRING:
-        BIO_printf(bio_out, "'%s'\n", (char *)p->data);
+        print_param_utf8((const char **)&p->data, p->return_size);
         break;
     case OSSL_PARAM_OCTET_PTR:
+        print_param_octet((const unsigned char **)p->data, p->return_size);
+        break;
     case OSSL_PARAM_OCTET_STRING:
-        BIO_printf(bio_out, "<%zu bytes>\n", p->data_size);
+        print_param_octet((const unsigned char **)&p->data, p->return_size);
         break;
     default:
         BIO_printf(bio_out, "unknown type (%u) of %zu bytes\n",
-                   p->data_type, p->data_size);
+                   p->data_type, p->return_size);
         break;
     }
 }
-

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1457,6 +1457,15 @@ OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
     return ossl_param_construct(key, OSSL_PARAM_OCTET_STRING, buf, bsize);
 }
 
+static int get_ptr_internal_skip_checks(const OSSL_PARAM *p, const void **val,
+                                        size_t *used_len)
+{
+    if (used_len != NULL)
+        *used_len = p->data_size;
+    *val = *(const void **)p->data;
+    return 1;
+}
+
 static int get_ptr_internal(const OSSL_PARAM *p, const void **val,
                             size_t *used_len, unsigned int type)
 {
@@ -1468,10 +1477,7 @@ static int get_ptr_internal(const OSSL_PARAM *p, const void **val,
         err_bad_type;
         return 0;
     }
-    if (used_len != NULL)
-        *used_len = p->data_size;
-    *val = *(const void **)p->data;
-    return 1;
+    return get_ptr_internal_skip_checks(p, val, used_len);
 }
 
 int OSSL_PARAM_get_utf8_ptr(const OSSL_PARAM *p, const char **val)
@@ -1645,12 +1651,17 @@ OSSL_PARAM OSSL_PARAM_construct_end(void)
 }
 
 static int get_string_ptr_internal(const OSSL_PARAM *p, const void **val,
-                                   size_t *used_len, unsigned int type)
+                                   size_t *used_len, unsigned int ref_type,
+                                   unsigned int type)
 {
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
     }
+
+    if (p->data_type == ref_type)
+        return get_ptr_internal_skip_checks(p, (const void **)val, used_len);
+
     if (p->data_type != type) {
         err_bad_type;
         return 0;
@@ -1663,25 +1674,15 @@ static int get_string_ptr_internal(const OSSL_PARAM *p, const void **val,
 
 int OSSL_PARAM_get_utf8_string_ptr(const OSSL_PARAM *p, const char **val)
 {
-    int rv;
-
-    ERR_set_mark();
-    rv = OSSL_PARAM_get_utf8_ptr(p, val);
-    ERR_pop_to_mark();
-
-    return rv || get_string_ptr_internal(p, (const void **)val, NULL,
-                                         OSSL_PARAM_UTF8_STRING);
+    return get_string_ptr_internal(p, (const void **)val, NULL,
+                                   OSSL_PARAM_UTF8_PTR,
+                                   OSSL_PARAM_UTF8_STRING);
 }
 
 int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
                                     size_t *used_len)
 {
-    int rv;
-
-    ERR_set_mark();
-    rv = OSSL_PARAM_get_octet_ptr(p, val, used_len);
-    ERR_pop_to_mark();
-
-    return rv || get_string_ptr_internal(p, val, used_len,
-                                         OSSL_PARAM_OCTET_STRING);
+    return get_string_ptr_internal(p, (const void **)val, used_len,
+                                   OSSL_PARAM_OCTET_PTR,
+                                   OSSL_PARAM_OCTET_STRING);
 }


### PR DESCRIPTION
The parameter value output library routine was incorrect.  It used the incorrect length when printing fetched parameter sizes.  It also printed a string which was potentially not zero terminated.  Both of these are addressed here.  Additionally, octet strings have their initial bytes printed in hex.

Refactor some of the param helper code; unifies some duplicated code.

Inspired by OpenSSL PR #27221 by Paul Dale

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
