### PR TITLE
Change Windows server 2019 to latest

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: [openssl-3.0, openssl-3.1, master]
-        os: [windows-2019, windows-2022]
+        os: [windows-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - windows-2022
         platform:
           - arch: win32
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - windows-2022
     runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
     steps:
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - windows-2022
     runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
     steps:
@@ -149,7 +149,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-latest
 # really worth while running, too? cygwin should mask this
 #          - windows-2022
         platform:


### PR DESCRIPTION
GitHub is removing Windows 2019 by June 30. So we keep 2022 and add windows-latest.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
