### PR TITLE
CI: enable periodic Coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,36 @@
+name: Coverity
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'quictls' }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: config
+      run: ./config
+    - name: Download Coverity
+      run: |
+        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=QuicTLS" -O coverity_tool.tar.gz
+        mkdir coverity_tool
+        tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
+    - name: Build with Coverity build tool
+      run: |
+        export PATH=`pwd`/coverity_tool/bin:$PATH
+        cov-build --dir cov-int make -s
+    - name: Submit build result to Coverity Scan
+      run: |
+        tar czvf cov.tar.gz cov-int
+        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+          --form email=rsalz@akamai.com \
+          --form file=@cov.tar.gz \
+          --form version="Commit $GITHUB_SHA" \
+          --form description="Build submitted via CI" \
+          https://scan.coverity.com/builds?project=QuicTLS

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,4 @@ Individuals
  * Watson Ladd
  * Shih-Ping Chan
  * William Ahern
+ * Ilia Shipitsin


### PR DESCRIPTION
The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)



things to do before merge

1) adding secret. secret from [Coverity](https://scan.coverity.com/projects/quictls?tab=project_settings) should be added to https://github.com/quictls/quictls/settings/secrets/actions --> new secret --> COVERITY_SCAN_TOKEN (paste secret from Coverity)

2) current schedule is daily `cron: "0 0 * * *"` - not sure how often should be built. maybe weekly


