### PR TITLE
Fix a ci test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ target_link_libraries(ssl-static PUBLIC crypto-static)
 ## define DSO_DLFCN
 
 add_custom_target(test
-	COMMAND SRCTOP=.. BLDTOP=. perl ../test/run_tests.pl
+    COMMAND SRCTOP=${CMAKE_SOURCE_DIR} BLDTOP=${CMAKE_BINARY_DIR} perl ${CMAKE_SOURCE_DIR}/test/run_tests.pl
 	VERBATIM
 	USES_TERMINAL
 	)

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -48,7 +48,7 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     cctx = SSL_CONF_CTX_new();
     if (cctx == NULL)
         goto err;
-    flags = SSL_CONF_FLAG_FILE;
+    flags = SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_SHOW_ERRORS;
     if (!system)
         flags |= SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_REQUIRE_PRIVATE;
     if (s != NULL) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2830,13 +2830,13 @@ typedef struct {
 
 static void get_sigorhash(int *psig, int *phash, const char *str)
 {
-    if (strcmp(str, "RSA") == 0) {
+    if (strcasecmp(str, "RSA") == 0) {
         *psig = EVP_PKEY_RSA;
-    } else if (strcmp(str, "RSA-PSS") == 0 || strcmp(str, "PSS") == 0) {
+    } else if (strcasecmp(str, "RSA-PSS") == 0 || strcasecmp(str, "PSS") == 0) {
         *psig = EVP_PKEY_RSA_PSS;
-    } else if (strcmp(str, "DSA") == 0) {
+    } else if (strcasecmp(str, "DSA") == 0) {
         *psig = EVP_PKEY_DSA;
-    } else if (strcmp(str, "ECDSA") == 0) {
+    } else if (strcasecmp(str, "ECDSA") == 0) {
         *psig = EVP_PKEY_EC;
     } else {
         *phash = OBJ_sn2nid(str);
@@ -2885,7 +2885,7 @@ static int sig_cb(const char *elem, int len, void *arg)
             /* Check if a provider supports the sigalg */
             for (i = 0; i < sarg->ctx->sigalg_list_len; i++) {
                 if (sarg->ctx->sigalg_list[i].sigalg_name != NULL
-                    && strcmp(etmp,
+                    && strcasecmp(etmp,
                               sarg->ctx->sigalg_list[i].sigalg_name) == 0) {
                     sarg->sigalgs[sarg->sigalgcnt++] =
                         sarg->ctx->sigalg_list[i].code_point;
@@ -2897,7 +2897,7 @@ static int sig_cb(const char *elem, int len, void *arg)
         if (sarg->ctx == NULL || i == sarg->ctx->sigalg_list_len) {
             for (i = 0, s = sigalg_lookup_tbl;
                  i < OSSL_NELEM(sigalg_lookup_tbl); i++, s++) {
-                if (s->name != NULL && strcmp(etmp, s->name) == 0) {
+                if (s->name != NULL && strcasecmp(etmp, s->name) == 0) {
                     sarg->sigalgs[sarg->sigalgcnt++] = s->sigalg;
                     break;
                 }

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 55
+num_tests = 54
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
@@ -56,7 +56,7 @@ test-50 = 50-TLS 1.3 ECDSA with brainpool
 test-51 = 51-TLS 1.2 DSA Certificate Test
 test-52 = 52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
 test-53 = 53-TLS 1.3 DSA Certificate Test
-test-54 = 54-TLS 1.3 ML-DSA Certificate Test
+
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -1746,34 +1746,3 @@ VerifyMode = Peer
 
 [test-53]
 ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[54-TLS 1.3 ML-DSA Certificate Test]
-ssl_conf = 54-TLS 1.3 ML-DSA Certificate Test-ssl
-
-[54-TLS 1.3 ML-DSA Certificate Test-ssl]
-server = 54-TLS 1.3 ML-DSA Certificate Test-server
-client = 54-TLS 1.3 ML-DSA Certificate Test-client
-
-[54-TLS 1.3 ML-DSA Certificate Test-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-cert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-key.pem
-SignatureAlgorithms = mlDSA44
-
-[54-TLS 1.3 ML-DSA Certificate Test-client]
-CipherString = DEFAULT
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-SignatureAlgorithms = mldsA44
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ml-dsa-44-cert.pem
-VerifyMode = Peer
-
-[test-54]
-ExpectedResult = Success
-
-


### PR DESCRIPTION
With this PR, the CI for tests is green!  There are a couple of questions to decide:

- Should we take on more of https://github.com/openssl/openssl/pull/26767, in particular (some of) the doc changes?
- This turned on a "set SSL options via config file" debugging flag on. There was really no way to do it except from within the low-level routine.  Should I remove that code? Add a new flag to invert the option, which will still not be readily usable?

I suppose those can be a follow-on PR after this is merge.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
