### PR TITLE
Fix cmake build failure when `OPENSSL_NO_TESTS` is provided.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,13 +208,15 @@ target_link_libraries(ssl-static PUBLIC crypto-static)
 #/* XXX NEED TO SET THESE */ include/crypto/dso_conf.h
 ## define DSO_DLFCN
 
-add_custom_target(test
-    COMMAND SRCTOP=${CMAKE_SOURCE_DIR} BLDTOP=${CMAKE_BINARY_DIR} perl ${CMAKE_SOURCE_DIR}/test/run_tests.pl
-	VERBATIM
-	USES_TERMINAL
-	)
-set_property(TARGET test PROPERTY EXCLUDE_FROM_ALL 1)
-add_dependencies(test build_tests)
+if (NOT OPENSSL_NO_TESTS)
+    add_custom_target(test
+        COMMAND SRCTOP=${CMAKE_SOURCE_DIR} BLDTOP=${CMAKE_BINARY_DIR} perl ${CMAKE_SOURCE_DIR}/test/run_tests.pl
+        VERBATIM
+        USES_TERMINAL
+        )
+    set_property(TARGET test PROPERTY EXCLUDE_FROM_ALL 1)
+    add_dependencies(test build_tests)
+endif ()
 
 include(hide_symbols.cmake)
 export_symbol(ssl libssl.sym)


### PR DESCRIPTION
Fixes cmake failure when `-DOPENSSL_NO_TESTS` is provided.

Reproduction steps:
```
$ git clone git@github.com:quictls/quictls.git
$ cd quictls && mkdir build && cd build
$ cmake -DOPENSSL_NO_TESTS=ON ..
```
Observe the following error:
```
CMake Error at CMakeLists.txt:217 (add_dependencies):
  The dependency target "build_tests" of target "test" does not exist.

```

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
