### PR TITLE
Improve QUIC defragmentation of TLS packets

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -570,7 +570,6 @@ int SSL_clear_quic(SSL *s)
     sc->quic_input_data_tail = NULL;
     BUF_MEM_free(sc->quic_buf);
     sc->quic_buf = NULL;
-    sc->quic_next_record_start = 0;
     memset(sc->client_hand_traffic_secret, 0, EVP_MAX_MD_SIZE);
     memset(sc->server_hand_traffic_secret, 0, EVP_MAX_MD_SIZE);
     memset(sc->client_early_traffic_secret, 0, EVP_MAX_MD_SIZE);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1183,8 +1183,11 @@ typedef struct cert_pkey_st CERT_PKEY;
 struct quic_data_st {
     struct quic_data_st *next;
     OSSL_ENCRYPTION_LEVEL level;
-    size_t start;       /* offset into quic_buf->data */
     size_t length;
+    /*
+     * char data[];
+     * Should be here but C90 variable-length arrays not allowed here.
+     */
 };
 typedef struct quic_data_st QUIC_DATA;
 int quic_set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL level);
@@ -1681,7 +1684,6 @@ struct ssl_st {
     int quic_transport_version;
     QUIC_DATA *quic_input_data_head;
     QUIC_DATA *quic_input_data_tail;
-    size_t quic_next_record_start;
     const SSL_QUIC_METHOD *quic_method;
 #endif
     /*

--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -157,7 +157,7 @@ OSSL_ENCRYPTION_LEVEL SSL_quic_write_level(const SSL *ssl)
 int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
                           const uint8_t *data, size_t len)
 {
-    size_t l, offset;
+    size_t l, fragment_length;;
 
     if (!SSL_is_quic(ssl)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
@@ -178,54 +178,41 @@ int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
     if (len == 0)
         return 1;
 
-    if (sc->quic_buf == NULL) {
-        BUF_MEM *buf;
-        if ((buf = BUF_MEM_new()) == NULL) {
-            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
-            return 0;
-        }
-        if (!BUF_MEM_grow(buf, SSL3_RT_MAX_PLAIN_LENGTH)) {
-            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
-            BUF_MEM_free(buf);
-            return 0;
-        }
-        sc->quic_buf = buf;
-        /* We preallocated storage, but there's still no *data*. */
-        sc->quic_buf->length = 0;
-        buf = NULL;
-    }
-
     /* A TLS message must not cross an encryption level boundary */
-    if (sc->quic_buf->length != sc->quic_next_record_start
-            && level != sc->quic_latest_level_received) {
+    fragment_length = ssl->quic_buf != NULL
+                        ? fragment_length = ssl->quic_buf->length : 0;
+    if (fragment_length != 0 && level != ssl->quic_latest_level_received) {
         ERR_raise(ERR_LIB_SSL, SSL_R_WRONG_ENCRYPTION_LEVEL_RECEIVED);
         return 0;
     }
     sc->quic_latest_level_received = level;
 
-    offset = sc->quic_buf->length;
-    if (!BUF_MEM_grow(sc->quic_buf, offset + len)) {
-        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
-        return 0;
+    if (fragment_length != 0) {
+        /*
+         * We have a partial record, copy the data into the buffer, and
+         * parse records from it.
+         */
+        if (!BUF_MEM_grow(ssl->quic_buf, fragment_length + len)) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        memcpy(ssl->quic_buf->data + fragment_length, data, len);
+        data = (const uint8_t *)ssl->quic_buf->data;
+        len = ssl->quic_buf->length;
     }
-    memcpy(sc->quic_buf->data + offset, data, len);
 
     /* Split on handshake message boundaries */
-    while (sc->quic_buf->length > sc->quic_next_record_start
-                                   + SSL3_HM_HEADER_LENGTH) {
+    while (len > SSL3_HM_HEADER_LENGTH) {
         QUIC_DATA *qd;
-        const uint8_t *p;
+        const uint8_t *p = data + 1;
 
-        /* TLS Handshake message header has 1-byte type and 3-byte length */
-        p = (const uint8_t *)sc->quic_buf->data
-            + sc->quic_next_record_start + 1;
         n2l3(p, l);
         l += SSL3_HM_HEADER_LENGTH;
         /* Don't allocate a QUIC_DATA if we don't have a full record */
-        if (l > sc->quic_buf->length - sc->quic_next_record_start)
+        if (l > len)
             break;
 
-        qd = OPENSSL_zalloc(sizeof(*qd));
+        qd = OPENSSL_zalloc(sizeof(*qd) + l);
         if (qd == NULL) {
             ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
             return 0;
@@ -233,15 +220,47 @@ int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
 
         qd->next = NULL;
         qd->length = l;
-        qd->start = sc->quic_next_record_start;
         qd->level = level;
+        memcpy((void *)(qd + 1), data, l);
 
         if (sc->quic_input_data_tail != NULL)
             sc->quic_input_data_tail->next = qd;
         else
             sc->quic_input_data_head = qd;
         sc->quic_input_data_tail = qd;
-        sc->quic_next_record_start += l;
+
+        /* Remove the now-consumed data. */
+        data += l;
+        len -= l;
+    }
+
+    /* If we have any unread data, we need to save it. */
+    if (len > 0) {
+        if (ssl->quic_buf != NULL) {
+            if (data == (const uint8_t *)ssl->quic_buf->data) {
+                /* Already in the buffer, no need to do anything.. */
+                return 1;
+            }
+        } else {
+            if ((ssl->quic_buf = BUF_MEM_new()) == NULL) {
+                ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+                return 0;
+            }
+        }
+        /*
+         * Note: 'data' might be in this buffer, but if that's the case,
+         * we're going to be shrinking the buffer, so the pointer will not be
+         * invalidated.  We do need to use memmove() and not memcpy(), though.
+         */
+        if (!BUF_MEM_grow(ssl->quic_buf, len)) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        memmove(ssl->quic_buf->data, data, len);
+    } else {
+        if (ssl->quic_buf != NULL) {
+            ssl->quic_buf->length = 0;
+        }
     }
 
     return 1;

--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -157,8 +157,6 @@ OSSL_ENCRYPTION_LEVEL SSL_quic_write_level(const SSL *ssl)
 int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
                           const uint8_t *data, size_t len)
 {
-    size_t l, fragment_length;;
-
     if (!SSL_is_quic(ssl)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
         return 0;
@@ -179,8 +177,7 @@ int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
         return 1;
 
     /* A TLS message must not cross an encryption level boundary */
-    fragment_length = ssl->quic_buf != NULL
-                        ? fragment_length = ssl->quic_buf->length : 0;
+    size_t fragment_length = ssl->quic_buf != NULL ? ssl->quic_buf->length : 0;
     if (fragment_length != 0 && level != ssl->quic_latest_level_received) {
         ERR_raise(ERR_LIB_SSL, SSL_R_WRONG_ENCRYPTION_LEVEL_RECEIVED);
         return 0;
@@ -204,6 +201,7 @@ int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
     /* Split on handshake message boundaries */
     while (len > SSL3_HM_HEADER_LENGTH) {
         QUIC_DATA *qd;
+        size_t l;
         const uint8_t *p = data + 1;
 
         n2l3(p, l);

--- a/ssl/statem/statem_quic.c
+++ b/ssl/statem/statem_quic.c
@@ -43,7 +43,7 @@ int quic_get_message(SSL *s, int *mt)
     }
 
     /* Copy buffered data */
-    memcpy(s->init_buf->data, s->quic_buf->data + qd->start, qd->length);
+    memcpy(s->init_buf->data, (void *)(qd + 1), qd->length);
     s->init_buf->length = qd->length;
     s->quic_input_data_head = qd->next;
     if (s->quic_input_data_head == NULL)


### PR DESCRIPTION
This avoids excessive persistent memory usage associated with every QUIC connection, by avoiding a large (21k) preallocation of a buffer used for defragmentation of TLS packets.

Instead of preallocating space for all TLS data, this only stores TLS fragments that cannot be fully assembled on the connection.

Fixes: #quictls/issues/12 (yes, again)

ping @wbl and @bwelling  to take a look.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
