### PR TITLE
Provide X509_CRL_get0_tbs_sigalg()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@ data format have been removed.
 library number is dynamic not static.
   - The unused and undocumented `BIO_f_linebuffer`, `BIO_f_reliable`, and
 `BIO_s_log` now return NULL.
+  - Add the missing X509_CRL_get0_tbs_sig() API to access the algorithm
+identifier in the signed portion of a CRL.
 
 - Header files were reorganized:
   - The redundant `#pragma once` and old-style header guards were removed.

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -124,6 +124,11 @@ STACK_OF(X509_REVOKED) *X509_CRL_get_REVOKED(X509_CRL *crl)
     return crl->crl.revoked;
 }
 
+const X509_ALGOR *X509_CRL_get0_tbs_sigalg(const X509_CRL *crl)
+{
+    return &crl->crl.sig_alg;
+}
+
 void X509_CRL_get0_signature(const X509_CRL *crl, const ASN1_BIT_STRING **psig,
                              const X509_ALGOR **palg)
 {

--- a/doc/man3/X509_get0_signature.pod
+++ b/doc/man3/X509_get0_signature.pod
@@ -5,7 +5,8 @@
 X509_get0_signature, X509_REQ_set0_signature, X509_REQ_set1_signature_algo,
 X509_get_signature_nid, X509_get0_tbs_sigalg, X509_REQ_get0_signature,
 X509_REQ_get_signature_nid, X509_CRL_get0_signature, X509_CRL_get_signature_nid,
-X509_get_signature_info, X509_SIG_INFO_get, X509_SIG_INFO_set - signature information
+X509_CRL_get0_tbs_sigalg, X509_get_signature_info,
+X509_SIG_INFO_get, X509_SIG_INFO_set - signature information
 
 =head1 SYNOPSIS
 
@@ -28,6 +29,7 @@ X509_get_signature_info, X509_SIG_INFO_get, X509_SIG_INFO_set - signature inform
                               const ASN1_BIT_STRING **psig,
                               const X509_ALGOR **palg);
  int X509_CRL_get_signature_nid(const X509_CRL *crl);
+ const X509_ALGOR *X509_CRL_get0_tbs_sigalg(const X509_crl *crl);
 
  int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
                              uint32_t *flags);
@@ -46,8 +48,8 @@ pointers which B<MUST NOT> be freed up after the call.
 X509_set0_signature() and X509_REQ_set1_signature_algo() are the
 equivalent setters for the two values of X509_get0_signature().
 
-X509_get0_tbs_sigalg() returns the signature algorithm in the signed
-portion of B<x>.
+X509_get0_tbs_sigalg() and X509_CRL_get0_tbs_sigalg() return the signature
+algorithm in the signed portion of the certificate or CRL.
 
 X509_get_signature_nid() returns the NID corresponding to the signature
 algorithm of B<x>.
@@ -129,6 +131,8 @@ added in OpenSSL 1.1.0.
 
 The X509_REQ_set0_signature() and X509_REQ_set1_signature_algo()
 were added in OpenSSL 1.1.1e.
+
+The X509_CRL_get0_tbs_sigalg() function was added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -718,6 +718,7 @@ OSSL_DEPRECATEDIN_1_1_0 ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *crl);
 X509_NAME *X509_CRL_get_issuer(const X509_CRL *crl);
 const STACK_OF(X509_EXTENSION) *X509_CRL_get0_extensions(const X509_CRL *crl);
 STACK_OF(X509_REVOKED) *X509_CRL_get_REVOKED(X509_CRL *crl);
+const X509_ALGOR *X509_CRL_get0_tbs_sigalg(const X509_CRL *crl);
 void X509_CRL_get0_signature(const X509_CRL *crl, const ASN1_BIT_STRING **psig,
                              const X509_ALGOR **palg);
 int X509_CRL_get_signature_nid(const X509_CRL *crl);

--- a/libcrypto.sym
+++ b/libcrypto.sym
@@ -4829,6 +4829,7 @@ X509_CRL_get0_extensions
 X509_CRL_get0_lastUpdate
 X509_CRL_get0_nextUpdate
 X509_CRL_get0_signature
+X509_CRL_get0_tbs_sigalg
 X509_CRL_get_ext
 X509_CRL_get_ext_by_critical
 X509_CRL_get_ext_by_NID

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -308,6 +308,7 @@ static int test_basic_crl(void)
 {
     X509_CRL *basic_crl = CRL_from_strings(kBasicCRL);
     X509_CRL *revoked_crl = CRL_from_strings(kRevokedCRL);
+    const X509_ALGOR *alg = NULL, *tbsalg;
     int r;
 
     r = TEST_ptr(basic_crl)
@@ -318,6 +319,14 @@ static int test_basic_crl(void)
         && TEST_int_eq(verify(test_leaf, test_root,
                               make_CRL_stack(basic_crl, revoked_crl),
                               X509_V_FLAG_CRL_CHECK), X509_V_ERR_CERT_REVOKED);
+    if (r) {
+        X509_CRL_get0_signature(basic_crl, NULL, &alg);
+        tbsalg = X509_CRL_get0_tbs_sigalg(basic_crl);
+        r = TEST_ptr(alg)
+            && TEST_ptr(tbsalg)
+            && TEST_int_eq(X509_ALGOR_cmp(alg, tbsalg), 0);
+    }
+
     X509_CRL_free(basic_crl);
     X509_CRL_free(revoked_crl);
     return r;


### PR DESCRIPTION
X509_CRL_get0_tbs_sigalg() corresponds to X509_get0_tbs_sigalg() and retrieves the AlgorithmIdentifier inside the TBSCertList which is not currently accessible in any sane way from public API.

This PR adds X509_get0_tbs_sigalg() to the public API, documents it, adds a simple regress check so there is coverage and mentions the addition in CHANGES.md.

Straightforward port of openssl/openssl/pull/27971

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
