### PR TITLE
make cmake bit happier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
-project(QuicTLS)
 cmake_minimum_required(VERSION 3.21)
+project(QuicTLS)
 enable_language(C ASM)
 
 # Build time, or epoch for reproducible


### PR DESCRIPTION
CMake Warning (dev) at CMakeLists.txt:2 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
