### PR TITLE
Remove dead code path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,7 +55,7 @@ removed the undocumented and otherwise unused "test non-blocking IO" BIO.
 - Several API changes were made:
   - The undocumented function `X509_OBJECT_up_ref_count` has been
 made private.
-  - Remove some depecrated (3.0) undocumented functions that were just
+  - Remove some deprecrated (3.0) undocumented functions that were just
 aliases for others: `BUF_strdup`, `BUF_strndup`, `BUF_memdup`,
 `BUF_strlcpy`, `BUF_strlcat`, and `BUF_strnlen`.
   - Removed some functions deprecated in the OpenSSL 1.1.0 release:
@@ -79,6 +79,7 @@ library number is dynamic not static.
 `OPENSSL_wipe_cpu` functions.
   - Add the missing X509_CRL_get0_tbs_sig() API to access the algorithm
 identifier in the signed portion of a CRL.
+  - Remove PEM_read_bio_secmem and PEM_FLAG_SECURE.
 
 - Header files were reorganized:
   - The redundant `#pragma once` and old-style header guards were removed.

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -897,7 +897,6 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
                     unsigned char **data, long *len_out, unsigned int flags)
 {
     EVP_ENCODE_CTX *ctx = NULL;
-    const BIO_METHOD *bmeth;
     BIO *headerB = NULL, *dataB = NULL;
     char *name = NULL;
     int len, taillen, headerlen, ret = 0;
@@ -911,10 +910,9 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
         ERR_raise(ERR_LIB_PEM, ERR_R_PASSED_INVALID_ARGUMENT);
         goto end;
     }
-    bmeth = (flags & PEM_FLAG_SECURE) ? BIO_s_secmem() : BIO_s_mem();
 
-    headerB = BIO_new(bmeth);
-    dataB = BIO_new(bmeth);
+    headerB = BIO_new(BIO_s_mem());
+    dataB = BIO_new(BIO_s_mem());
     if (headerB == NULL || dataB == NULL) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BIO_LIB);
         goto end;

--- a/doc/man3/PEM_read_bio_ex.pod
+++ b/doc/man3/PEM_read_bio_ex.pod
@@ -2,14 +2,13 @@
 
 =head1 NAME
 
-PEM_read_bio_ex, PEM_FLAG_SECURE, PEM_FLAG_EAY_COMPATIBLE,
+PEM_read_bio_ex, PEM_FLAG_EAY_COMPATIBLE,
 PEM_FLAG_ONLY_B64 - read PEM format files with custom processing
 
 =head1 SYNOPSIS
 
  #include <openssl/pem.h>
 
- #define PEM_FLAG_SECURE             0x0
  #define PEM_FLAG_EAY_COMPATIBLE     0x2
  #define PEM_FLAG_ONLY_B64           0x4
  int PEM_read_bio_ex(BIO *in, char **name, char **header,
@@ -23,8 +22,6 @@ the possibly encrypted data, and the binary data payload (after base64 decoding)
 It should generally only be used to implement PEM_read_bio_-family functions
 for specific data types or other usage, but is exposed to allow greater flexibility
 over how processing is performed, if needed.
-
-PEM_FLAG_SECURE is ignored.
 
 If PEM_FLAG_EAY_COMPATIBLE is set, a simple algorithm is used to remove whitespace
 and control characters from the end of each line, so as to be compatible with

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -371,7 +371,6 @@ int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *len,
 
 int PEM_read_bio(BIO *bp, char **name, char **header,
                  unsigned char **data, long *len);
-#   define PEM_FLAG_SECURE             0x0
 #   define PEM_FLAG_EAY_COMPATIBLE     0x2
 #   define PEM_FLAG_ONLY_B64           0x4
 int PEM_read_bio_ex(BIO *bp, char **name, char **header,

--- a/util/other.syms
+++ b/util/other.syms
@@ -501,7 +501,6 @@ OSSL_QUIC_ERR_CRYPTO_ERR                define
 OSSL_QUIC_LOCAL_ERR_IDLE_TIMEOUT        define
 PEM_FLAG_EAY_COMPATIBLE                 define
 PEM_FLAG_ONLY_B64                       define
-PEM_FLAG_SECURE                         define
 RAND_cleanup                            define deprecated 1.1.0
 SSL_COMP_free_compression_methods       define deprecated 1.1.0
 SSL_CTX_add0_chain_cert                 define


### PR DESCRIPTION
Since code that tries to us PEM_read_bio_secmem will need changes anyway, just remove the define completely.
Coverity found this.

Ping @wbl
The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
