### PR TITLE
architecture-dependent bn_asm

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,6 +21,7 @@ Individuals
  * William Ahern
  * Ilia Shipitsin
  * Guillaume Hetier
+ * Zsombor Kalo
 
 
 Groups

--- a/crypto/bn/CMakeLists.txt
+++ b/crypto/bn/CMakeLists.txt
@@ -64,7 +64,7 @@ endif ()
 if (OPENSSL_NO_ASM)
     list(APPEND SOURCE bn_asm.c)
  else ()
-    list(APPEND SOURCE ${bnasm_x86_64})
+    list(APPEND SOURCE ${bnasm_${ARCH}})
 endif ()
 
 list(APPEND SOURCE


### PR DESCRIPTION
The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)

A step forward to successful build on other CPU architectures. 
With this patch, libcrypto and libssl  can be built on ARM.