### PR TITLE
Address some coverity warnings

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -91,7 +91,9 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_ASYM_CIPHER_free(cipher);
+        cipher = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:
@@ -128,12 +130,15 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
         if (tmp_keymgmt != NULL)
             provkey = evp_pkey_export_to_provider(ctx->pkey, ctx->libctx,
                                                   &tmp_keymgmt, ctx->propquery);
-        if (tmp_keymgmt == NULL)
+        if (tmp_keymgmt == NULL) {
             EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+            tmp_keymgmt_tofree = NULL;
+        }
     }
 
     if (provkey == NULL) {
         EVP_ASYM_CIPHER_free(cipher);
+        cipher = NULL;
         goto legacy;
     }
 

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -227,6 +227,7 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
             || (pkey->keydata = evp_keymgmt_newdata(ctx->keymgmt)) == NULL) {
             ERR_clear_last_mark();
             EVP_PKEY_free(pkey);
+            pkey = NULL;
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             goto err;
         }
@@ -277,7 +278,9 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
          * iteration we're on.
          */
         EVP_KEYEXCH_free(exchange);
+        exchange = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:
@@ -314,12 +317,15 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
         if (tmp_keymgmt != NULL)
             provkey = evp_pkey_export_to_provider(ctx->pkey, ctx->libctx,
                                                   &tmp_keymgmt, ctx->propquery);
-        if (tmp_keymgmt == NULL)
+        if (tmp_keymgmt == NULL) {
             EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+            tmp_keymgmt_tofree = NULL;
+        }
     }
 
     if (provkey == NULL) {
         EVP_KEYEXCH_free(exchange);
+        exchange = NULL;
         goto legacy;
     }
 
@@ -400,6 +406,7 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
             return -1;
         check = EVP_PKEY_public_check(check_ctx);
         EVP_PKEY_CTX_free(check_ctx);
+        check_ctx = NULL;
         if (check <= 0)
             return -1;
     }
@@ -424,6 +431,7 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
         provkey = evp_pkey_export_to_provider(peer, ctx->libctx,
                                               &tmp_keymgmt, ctx->propquery);
     EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+    tmp_keymgmt_tofree = NULL;
 
     /*
      * If making the key provided wasn't possible, legacy may be able to pick

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -87,7 +87,9 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_KEM_free(kem);
+        kem = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:
@@ -132,17 +134,21 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
                                                           ctx->propquery);
                 if (provauthkey == NULL) {
                     EVP_KEM_free(kem);
+                    kem = NULL;
                     ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
                     goto err;
                 }
             }
         }
-        if (tmp_keymgmt == NULL)
+        if (tmp_keymgmt == NULL) {
             EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+            tmp_keymgmt_tofree = NULL;
+        }
     }
 
     if (provkey == NULL) {
         EVP_KEM_free(kem);
+        kem = NULL;
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -141,7 +141,9 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
          * iteration we're on.
          */
         EVP_SIGNATURE_free(signature);
+        signature = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:
@@ -179,12 +181,15 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         if (tmp_keymgmt != NULL)
             provkey = evp_pkey_export_to_provider(locpctx->pkey, locpctx->libctx,
                                                   &tmp_keymgmt, locpctx->propquery);
-        if (tmp_keymgmt == NULL)
+        if (tmp_keymgmt == NULL) {
             EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+            tmp_keymgmt_tofree = NULL;
+        }
     }
 
     if (provkey == NULL) {
         EVP_SIGNATURE_free(signature);
+        signature = NULL;
         ERR_clear_last_mark();
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
@@ -557,6 +562,7 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
             else
                 r = EVP_DigestFinal_ex(tmp_ctx, md, &mdlen);
             EVP_MD_CTX_free(tmp_ctx);
+            tmp_ctx = NULL;
         }
         if (sctx || !r)
             return r;

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -460,7 +460,9 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_SIGNATURE_free(signature);
+        signature = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:
@@ -498,12 +500,15 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
         if (tmp_keymgmt != NULL)
             provkey = evp_pkey_export_to_provider(ctx->pkey, ctx->libctx,
                                                   &tmp_keymgmt, ctx->propquery);
-        if (tmp_keymgmt == NULL)
+        if (tmp_keymgmt == NULL) {
             EVP_KEYMGMT_free(tmp_keymgmt_tofree);
+            tmp_keymgmt_tofree = NULL;
+        }
     }
 
     if (provkey == NULL) {
         EVP_SIGNATURE_free(signature);
+        signature = NULL;
         goto legacy;
     }
 


### PR DESCRIPTION
After xxx_free(foo); add "foo = NULL"

I wonder if all the xxx_free() functions should be changed to "return NULL;" then we could do
```
foo = xxx_free(foo);
```

Or is that too tricky?  It would make it less likely we forget to add the NULL assignment.

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
