### PR TITLE
use OPENSSL_strlcat instead of strcat

### DIFF
--- a/crypto/cmp/cmp_genm.c
+++ b/crypto/cmp/cmp_genm.c
@@ -125,7 +125,7 @@ static OSSL_CMP_ITAV *get_genm_itav(OSSL_CMP_CTX *ctx,
         }
 
         if (OBJ_obj2txt(name + offset, sizeof(name) - offset, obj, 0) < 0)
-            OPENSSL_strlcat(name, "<unknown>", 128);
+            OPENSSL_strlcat(name, "<unknown>", sizeof(name));
         ossl_cmp_log2(WARN, ctx, "%s' while expecting 'id-it-%s'", name, desc);
         OSSL_CMP_ITAV_free(itav);
     }

--- a/crypto/cmp/cmp_genm.c
+++ b/crypto/cmp/cmp_genm.c
@@ -125,7 +125,7 @@ static OSSL_CMP_ITAV *get_genm_itav(OSSL_CMP_CTX *ctx,
         }
 
         if (OBJ_obj2txt(name + offset, sizeof(name) - offset, obj, 0) < 0)
-            strcat(name, "<unknown>");
+            OPENSSL_strlcat(name, "<unknown>", 128);
         ossl_cmp_log2(WARN, ctx, "%s' while expecting 'id-it-%s'", name, desc);
         OSSL_CMP_ITAV_free(itav);
     }


### PR DESCRIPTION
This prevents a possible buffer overflow should OBJ_obj2txt encounter an error after partially filling the buffer.

This bug was reported to Akamai by user https://hackerone.com/amalyoman.

Note: I don't know whether this is a practically exploitable issue or not, but as general good hygiene, it seemed prudent to avoid strcat(3).

The PR will not be merged without the following checked:
- [X] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
