### PR TITLE
avoid signed-to-unsigned integer conversion

### DIFF
--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -358,7 +358,7 @@ int quic_set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL level)
         }
     }
 
-    if (md == NULL) || (len = EVP_MD_size(md)) <= 0) {
+    if (md == NULL || (len = EVP_MD_size(md)) <= 0) {
         SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -289,7 +289,7 @@ int quic_set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL level)
 {
     uint8_t *c2s_secret = NULL;
     uint8_t *s2c_secret = NULL;
-    size_t len;
+    int len;
     const EVP_MD *md;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
 
@@ -358,7 +358,7 @@ int quic_set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL level)
         }
     }
 
-    if ((len = EVP_MD_size(md)) <= 0) {
+    if ((md == NULL) || ((len = EVP_MD_size(md)) <= 0)) {
         SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -358,7 +358,7 @@ int quic_set_encryption_secrets(SSL *ssl, OSSL_ENCRYPTION_LEVEL level)
         }
     }
 
-    if ((md == NULL) || ((len = EVP_MD_size(md)) <= 0)) {
+    if (md == NULL) || (len = EVP_MD_size(md)) <= 0) {
         SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }


### PR DESCRIPTION
Should EVP_MD_size() return -1, the size_t len variable would wrap, causing the subsequent error check to not trigger. Change to type int (which is what EVP_MD_size() returns) and explicitly guard against 'md == NULL'.

In practice, 'md' being passwd to EVP_MD_size() as NULL appears functionally unreachable, but this still is a bug lurking here.

This issue has been reported multiple times to Akamai's Bug Bounty program.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
