### PR TITLE
pedantically use int to avoid signed-unsigned discrepancy

### DIFF
--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -287,6 +287,7 @@ static int test_handshake_secrets(void)
     SSL_CTX *ctx = NULL;
     SSL *s = NULL;
     int ret = 0;
+    int sz = 0;
     size_t hashsize;
     unsigned char out_master_secret[EVP_MAX_MD_SIZE];
     size_t master_secret_length;
@@ -325,7 +326,10 @@ static int test_handshake_secrets(void)
                      handshake_secret, sizeof(handshake_secret)))
         goto err;
 
-    hashsize = EVP_MD_get_size(ssl_handshake_md(s));
+    sz = EVP_MD_get_size(ssl_handshake_md(s));
+    if (sz < 0)
+        goto err;
+    hashsize = (size_t)sz;
     if (!TEST_size_t_eq(sizeof(client_hts), hashsize))
         goto err;
     if (!TEST_size_t_eq(sizeof(client_hts_key), KEYLEN))


### PR DESCRIPTION
This would be caught by the subsequent check, but because in https://github.com/quictls/quictls/issues/340 I made the point of test/demo code being copied around by folks, illustrating the right types here might still have some non-zero value.

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
