### PR TITLE
cleanup crypto/hpke/hpke_util.c: remove warning of cppcheck

### DIFF
--- a/crypto/hpke/hpke_util.c
+++ b/crypto/hpke/hpke_util.c
@@ -406,9 +406,8 @@ EVP_KDF_CTX *ossl_kdf_ctx_create(const char *kdfname, const char *mdname,
     if (kctx != NULL && mdname != NULL) {
         OSSL_PARAM params[3], *p = params;
 
-        if (mdname != NULL)
-            *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                                    (char *)mdname, 0);
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+                                                (char *)mdname, 0);
         if (propq != NULL)
             *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_PROPERTIES,
                                                     (char *)propq, 0);


### PR DESCRIPTION
crypto/hpke/hpke_util.c:409:20: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
