### PR TITLE
test/evp_kdf_test.c: fix always-false condition in test_kdf_pbkdf2_la…

### DIFF
--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -684,7 +684,7 @@ static int test_kdf_pbkdf2_large_output(void)
     int mode = 0;
     OSSL_PARAM *params;
 
-    if (sizeof(len) > 32)
+    if (sizeof(len) * CHAR_BIT > 32)
         len = SIZE_MAX;
 
     params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",


### PR DESCRIPTION
…rge_output

sizeof(len) returns the size of size_t in bytes (8 on a 64-bit platform), which can never exceed 32.  The intent of the guard is to detect a 64-bit size_t so that SIZE_MAX can be used to exercise the "key length too large" error path in EVP_KDF_derive().

Replace `sizeof(len) > 32` with `sizeof(len) * CHAR_BIT > 32` so the condition evaluates to true whenever size_t is wider than 32 bits.

Without this fix, `len` stays 0 and the EVP_KDF_derive() call is skipped entirely (short-circuited by `len != 0`), meaning the oversized-output rejection was never actually tested on any platform.

CHAR_BIT is available via the existing #include <internal/numbers.h>.

Fixes: f0efeea29e ("PBKDF2 updates to conform to SP800-132")

The PR will not be merged without the following checked:
- [x] I acknowledge that I am authorized to submit this code under
the terms of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
